### PR TITLE
Add more NICs on XRv

### DIFF
--- a/xrv/README.md
+++ b/xrv/README.md
@@ -67,18 +67,15 @@ production traffic.
 ##### Q: Why not use XRv9000?
 A: It seems that all the forwarding plane features that I am looking for are
 available in XRv and so there is very little benefit to XRv9000. On the
-contrary, XRv supports up to 96 interfaces
+contrary, XRv supports up to 128 interfaces
 (http://www.cisco.com/c/en/us/td/docs/ios_xr_sw/ios_xrv/install_config/b-xrv/b-xrv_chapter_01.html)
 with a single VM whereas XRv9000 seems to support up to 11 NICs (see
 http://www.cisco.com/c/en/us/td/docs/routers/virtual-routers/configuration/guide/b-xrv9k-cg/b-xrv9k-cg_chapter_0111.html).
 
-##### Q: How come there are only 16 NICs?
-A: AFAICT, qemu has a limit of one PCI bus and each PCI bus can support 32
-devices. IDE controller and similar consume some devices so we should be left
-with ~28 available PCI devices that could be used for NICs, however I have seen
-issues with using more than 17 NICs (16+1 mgmt) and so the limit is currently
-set lower. I imagine it can be raised by careful testing - perhaps it's XRv
-version or qemu version dependent!?
+##### Q: How many NICs are supported?
+A: 128, which is the maximum as specified by Cisco. I use multiple PCI buses to
+reach this number and while the current setting is for 128 I have successfully
+started XRv with more although I have not done any thorough testing.
 
 ##### Q: Is a license required?
 A: Yes and no. XRv can run in a demo mode or a production mode, where the

--- a/xrv/docker/launch_xrv.py
+++ b/xrv/docker/launch_xrv.py
@@ -59,7 +59,7 @@ class XRV:
         self.password = password
 
         self.ram = 4096
-        self.num_nics = 16
+        self.num_nics = 128
 
         self.state = 0
 
@@ -96,6 +96,13 @@ class XRV:
         """
 
         cmd = ["qemu-system-x86_64", "-display", "none", "-daemonize", "-m", str(self.ram),
+               "-machine", "pc",
+               "-device", "pci-bridge,chassis_nr=1,id=pci.0",
+               "-device", "pci-bridge,chassis_nr=2,id=pci.1",
+               "-device", "pci-bridge,chassis_nr=3,id=pci.2",
+               "-device", "pci-bridge,chassis_nr=4,id=pci.3",
+               "-device", "pci-bridge,chassis_nr=5,id=pci.4",
+               "-device", "pci-bridge,chassis_nr=6,id=pci.5",
                "-serial", "telnet:0.0.0.0:5000,server,nowait",
                "-hda", "/xrv.vmdk"
                ]
@@ -105,19 +112,22 @@ class XRV:
 
         # mgmt interface is special - we use qemu user mode network
         cmd.append("-device")
-        cmd.append("e1000,netdev=p%(i)02d,mac=%(mac)s"
-                   % { 'i': 0, 'mac': gen_mac(0) })
+        cmd.append("e1000,netdev=mgmt,mac=%(mac)s"
+                   % { 'mac': gen_mac(0) })
         cmd.append("-netdev")
-        cmd.append("user,id=p%(i)02d,net=10.0.0.0/24,hostfwd=tcp::2022-10.0.0.15:22,hostfwd=tcp::2830-10.0.0.15:830"
-                   % { 'i': 0 })
+        cmd.append("user,id=mgmt,net=10.0.0.0/24,hostfwd=tcp::2022-10.0.0.15:22,hostfwd=tcp::2830-10.0.0.15:830")
 
-        for i in range(1, self.num_nics):
+        for i in range(self.num_nics):
+            import math
+            nics_per_pci_bus = 26
+            pci_bus = math.floor(i/nics_per_pci_bus)
+            addr = i % nics_per_pci_bus
             cmd.append("-device")
-            cmd.append("e1000,netdev=p%(i)02d,mac=%(mac)s"
-                       % { 'i': i, 'mac': gen_mac(i) })
+            cmd.append("e1000,netdev=p%(i)02d,mac=%(mac)s,bus=pci.%(pci_bus)d,addr=0x%(addr)x"
+                       % { 'i': i, 'mac': gen_mac(i), 'pci_bus': pci_bus+1, 'addr': addr+1 })
             cmd.append("-netdev")
             cmd.append("socket,id=p%(i)02d,listen=:100%(i)02d"
-                       % { 'i': i })
+                       % { 'i': i+1 }) # offset by one if we want to mgmt on 0 later
 
         run_command(cmd)
 


### PR DESCRIPTION
This adds 128 NICs to XRv which is the maximum as specified by Cisco. I was able to start it with more but don't know if that will lead to other issues.