### PR TITLE
Add --listen option and filter announcements based on address family

### DIFF
--- a/vr-bgp/Dockerfile
+++ b/vr-bgp/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -qy \
     telnet \
     wget \
  && rm -rf /var/lib/apt/lists/* \
- && wget -O exabgp.tar.gz https://github.com/Exa-Networks/exabgp/archive/3.4.16.tar.gz \
+ && wget -O exabgp.tar.gz https://github.com/Exa-Networks/exabgp/archive/3.4.18.tar.gz \
  && tar zxvf exabgp.tar.gz \
  && cd /exabgp* && python setup.py install \
  && cd / && rm -rf exabgp*

--- a/vr-bgp/exabgp.conf.tpl
+++ b/vr-bgp/exabgp.conf.tpl
@@ -20,12 +20,22 @@ group test {
     neighbor {{config.IPV4_NEIGHBOR}} {
         peer-as {{config.PEER_AS}};
         local-address {{config.IPV4_LOCAL_ADDRESS}};
+        {% if config.LIMIT_AFI %}
+        family {
+            ipv4 unicast;
+        }
+        {% endif %}
     }
 {% endif %}
 {% if config.IPV6_NEIGHBOR %}
     neighbor {{config.IPV6_NEIGHBOR}} {
         peer-as {{config.PEER_AS}};
         local-address {{config.IPV6_LOCAL_ADDRESS}};
+        {% if config.LIMIT_AFI %}
+        family {
+            ipv6 unicast;
+        }
+        {% endif %}
     }
 {% endif %}
 }

--- a/vr-bgp/vr-bgp.py
+++ b/vr-bgp/vr-bgp.py
@@ -31,6 +31,7 @@ if __name__ == '__main__':
     parser.add_argument('--ipv6-local-address', help='local address or route table will be used')
     parser.add_argument('--ipv6-neighbor', help='IP address of the neighbor')
     parser.add_argument('--ipv6-prefix', help='IP prefix to configure on the link')
+    parser.add_argument('--listen', choices=['ipv4', 'ipv6'], help='listen on <ipv4> or <ipv6> local-address')
     parser.add_argument('--local-as', required=True, help='local AS')
     parser.add_argument('--router-id', required=True, help='our router-id')
     parser.add_argument('--peer-as', required=True, help='peer AS')
@@ -60,7 +61,7 @@ if __name__ == '__main__':
         'IPV6_LOCAL_ADDRESS': None,
         'LOCAL_AS': args.local_as,
         'PEER_AS': args.peer_as,
-        'ROUTER_ID': args.router_id or '192.0.2.255',
+        'ROUTER_ID': args.router_id or '192.0.2.255'
     }
 
     subprocess.check_call(["ip", "link", "set", "tap0", "up"])
@@ -137,6 +138,21 @@ if __name__ == '__main__':
             print("--ipv6-local-address requires --ipv6-prefix to be specified", file=sys.stderr)
             sys.exit(1)
 
+    bind_config = []
+    if args.listen == 'ipv4':
+        if config['IPV4_LOCAL_ADDRESS']:
+            bind_config = ['env', 'exabgp.tcp.bind={}'.format(config['IPV4_LOCAL_ADDRESS'])]
+        else:
+            print("--listen ipv4 requires --ipv4-local-address")
+            sys.exit(1)
+
+    if args.listen == 'ipv6':
+        if config['IPV6_LOCAL_ADDRESS']:
+            bind_config = ['env', 'exabgp.tcp.bind={}'.format(config['IPV6_LOCAL_ADDRESS'])]
+        else:
+            print("--listen ipv6 requires --ipv6-local-address")
+            sys.exit(1)
+
 
     # generate exabgp config using Jinja2 template
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(['/']))
@@ -145,6 +161,10 @@ if __name__ == '__main__':
     exa_config.write(template.render(config=config))
     exa_config.close()
     # start exabgp
-    exap = subprocess.Popen(["exabgp", "/exabgp.conf"])
+    exap = subprocess.Popen(bind_config + ["exabgp", "/exabgp.conf"])
     while True:
+        if exap.poll() == 0:
+            print("exabgp stopped, restarting in 2s")
+            time.sleep(2)
+            exap = subprocess.Popen(bind_config + ["exabgp", "/exabgp.conf"])
         time.sleep(1)

--- a/vr-bgp/vr-bgp.py
+++ b/vr-bgp/vr-bgp.py
@@ -32,6 +32,7 @@ if __name__ == '__main__':
     parser.add_argument('--ipv6-neighbor', help='IP address of the neighbor')
     parser.add_argument('--ipv6-prefix', help='IP prefix to configure on the link')
     parser.add_argument('--listen', choices=['ipv4', 'ipv6'], help='listen on <ipv4> or <ipv6> local-address')
+    parser.add_argument('--limit-announce-to-afi', action='store_true', help='limit announced prefixes to neighbor AFI')
     parser.add_argument('--local-as', required=True, help='local AS')
     parser.add_argument('--router-id', required=True, help='our router-id')
     parser.add_argument('--peer-as', required=True, help='peer AS')
@@ -61,7 +62,8 @@ if __name__ == '__main__':
         'IPV6_LOCAL_ADDRESS': None,
         'LOCAL_AS': args.local_as,
         'PEER_AS': args.peer_as,
-        'ROUTER_ID': args.router_id or '192.0.2.255'
+        'ROUTER_ID': args.router_id or '192.0.2.255',
+        'LIMIT_AFI': args.limit_announce_to_afi
     }
 
     subprocess.check_call(["ip", "link", "set", "tap0", "up"])


### PR DESCRIPTION
The new `--listen (ipv4|ipv6)` option will enable a BGP listener on the `--ipv(4|6)-local-address`.

The new `--limit-announce-to-afi` option (not sure about the name here, feel free to change) will configure an appropriate `family` for the neighbor, preventing announcement of IPv4 prefixes to IPv6 neighbors, and vice versa.

The patch also includes a fix for the announcement receiver to correctly parse a special case of `eor` update.