### PR TITLE
Added --wait-for-boot feature for config-engine-lite

### DIFF
--- a/config-engine-lite/configengine
+++ b/config-engine-lite/configengine
@@ -5,7 +5,7 @@ import sys
 import jinja2
 import pprint
 import napalm
-import paramiko.ssh_excepion
+import paramiko.ssh_exception
 import time
 
 class RouterList:
@@ -201,7 +201,7 @@ if __name__ == '__main__':
     parser.add_argument("--junos", help="JunOS template")
     parser.add_argument("--ios", help="IOS template")
     parser.add_argument("--run", help="Apply configuration", default=False, action="store_true")
-    parser.add_argument("--wait-for-boot", help="Retry connection until sucessful", default=False, action="store_true")
+    parser.add_argument("--wait-for-boot", help="Retry connection until successful", default=False, action="store_true")
     args = parser.parse_args()
 
     if args.xr:

--- a/config-engine-lite/configengine
+++ b/config-engine-lite/configengine
@@ -134,7 +134,7 @@ class ConfigBootstrap:
             if router.type == "vmx":
                 router.template = junos
 
-            if router.type == "crs":
+            if router.type == "csr":
                 router.template = ios
 
             self.routers.append(router)

--- a/config-engine-lite/configengine
+++ b/config-engine-lite/configengine
@@ -6,6 +6,7 @@ import jinja2
 import pprint
 import napalm
 import paramiko.ssh_exception
+import jnpr.junos.exception
 import time
 
 class RouterList:
@@ -60,6 +61,11 @@ class Router:
                 except paramiko.ssh_exception.SSHException:
                     # xrv and csr throws this exception when connection
                     # failed, wait a bit and retry.
+                    TIMER += 2
+                    time.sleep(2)
+                except jnpr.junos.exception.ConnectError:
+                    # vmx throws this exception when connection failed
+                    # wait a bit and retry
                     TIMER += 2
                     time.sleep(2)
         else:
@@ -170,7 +176,7 @@ class ConfigBootstrap:
             })
             i = i + 1
 
-    def render_config(self):
+    def render_config(self, noop=False):
         for router in self.routers.list():
             config = {
                 "hostname": router.name, 
@@ -182,6 +188,9 @@ class ConfigBootstrap:
                 config[key] = router.attrs[key]
 
             router.connect(self.wait_for_boot)
+
+            if noop:
+                continue
 
             env = jinja2.Environment(loader=jinja2.FileSystemLoader(['./']))
             template = env.get_template(router.template)
@@ -208,6 +217,7 @@ if __name__ == '__main__':
     parser.add_argument("--ios", help="IOS template")
     parser.add_argument("--run", help="Apply configuration", default=False, action="store_true")
     parser.add_argument("--wait-for-boot", help="Retry connection until successful", default=False, action="store_true")
+    parser.add_argument("--noop", help="Only connect to routers, don't attempt to load any configuration", default=False, action="store_true")
     args = parser.parse_args()
 
     if args.xr:
@@ -229,14 +239,18 @@ if __name__ == '__main__':
         print("Topology file does not exist")
         sys.exit(1)
 
+    if args.run and args.noop:
+        print("Don't use --run and --noop at the same time, please")
+        sys.exit(1)
+
     input_file = open(args.topo, "r")
     config = json.loads(input_file.read())
     input_file.close()
 
     cb = ConfigBootstrap(config, args.xr, args.junos, args.ios, args.wait_for_boot)
-    cb.render_config()
+    cb.render_config(args.noop)
 
     if args.run:
         cb.apply_config()
-    else:
+    if not args.run and not args.noop:
         cb.diff_config()

--- a/config-engine-lite/configengine
+++ b/config-engine-lite/configengine
@@ -5,6 +5,8 @@ import sys
 import jinja2
 import pprint
 import napalm
+import paramiko.ssh_excepion
+import time
 
 class RouterList:
     def __init__(self):
@@ -33,7 +35,7 @@ class Router:
         self.device = None
         self.loaded = False
 
-    def connect(self):
+    def connect(self, wait_for_boot=False):
         if self.type == "xrv":
             driver = napalm.get_network_driver("iosxr")
         elif self.type == "vmx":
@@ -44,8 +46,19 @@ class Router:
             raise Exception("Unknown device type: {}".format(self.type))
 
         self.device = driver(self.get_address(), "vrnetlab", "VR-netlab9")
-        self.device.open()
-        return self.device
+
+        if wait_for_boot:
+            while True:
+                try:
+                    self.device.open()
+                    return self.device
+                except paramiko.ssh_exception.SSHException:
+                    # xrv and csr throws this exception when connection
+                    # failed, wait a bit and retry.
+                    time.sleep(2)
+        else:
+            self.device.open()
+            return self.device
 
     def load_merge(self):
         if not self.device:
@@ -88,8 +101,9 @@ class Router:
         self.attrs[key] = value
 
 class ConfigBootstrap:
-    def __init__(self, config, xr, junos, ios):
+    def __init__(self, config, xr, junos, ios, wait_for_boot):
         self.routers = RouterList()
+        self.wait_for_boot = wait_for_boot
 
         i = 1
         for name in config["routers"]:
@@ -161,6 +175,8 @@ class ConfigBootstrap:
             for key in router.attrs:
                 config[key] = router.attrs[key]
 
+            router.connect(self.wait_for_boot)
+
             env = jinja2.Environment(loader=jinja2.FileSystemLoader(['./']))
             template = env.get_template(router.template)
             router.config = template.render(config)
@@ -185,6 +201,7 @@ if __name__ == '__main__':
     parser.add_argument("--junos", help="JunOS template")
     parser.add_argument("--ios", help="IOS template")
     parser.add_argument("--run", help="Apply configuration", default=False, action="store_true")
+    parser.add_argument("--wait-for-boot", help="Retry connection until sucessful", default=False, action="store_true")
     args = parser.parse_args()
 
     if args.xr:
@@ -210,7 +227,7 @@ if __name__ == '__main__':
     config = json.loads(input_file.read())
     input_file.close()
 
-    cb = ConfigBootstrap(config, args.xr, args.junos, args.ios)
+    cb = ConfigBootstrap(config, args.xr, args.junos, args.ios, args.wait_for_boot)
     cb.render_config()
 
     if args.run:

--- a/config-engine-lite/configengine
+++ b/config-engine-lite/configengine
@@ -46,15 +46,21 @@ class Router:
             raise Exception("Unknown device type: {}".format(self.type))
 
         self.device = driver(self.get_address(), "vrnetlab", "VR-netlab9")
+        TIMEOUT = 60*15
+        TIMER = 0
 
         if wait_for_boot:
             while True:
                 try:
+                    if TIMER >= TIMEOUT:
+                        # Timeout if router hasn't started in 15 minutes.
+                        raise TimeoutError("Timed out wating for router {} to start".format(self.name))
                     self.device.open()
                     return self.device
                 except paramiko.ssh_exception.SSHException:
                     # xrv and csr throws this exception when connection
                     # failed, wait a bit and retry.
+                    TIMER += 2
                     time.sleep(2)
         else:
             self.device.open()


### PR DESCRIPTION
With --wait-for-boot, config-engine-lite blocks until each router has booted and is available over SSH. --noop is provided as a method to block execution until all routers in your topology is ready without altering configuration on them.