### PR TITLE
Fixed ugly --attrs list syntax

### DIFF
--- a/config-engine-lite/README.md
+++ b/config-engine-lite/README.md
@@ -46,7 +46,7 @@ docker run -v $(pwd)/templates:/templates --link router1 vr-configengine --type 
  * --link router1 - Link the router you want to configure
  * --config /templates/router1.j2 - Your router configuration, references /templates moutpoint
  * --type vmx - Type of router to configure (valid values are vmx, xrv and csr)
- * --attrs "key1=value1,key2=value2" - A list of key/value pairs available in the template.
+ * --attr "key=value" - A key/value pair available in the template, can be specified multiple times.
 
 ### Common parameters
 These parameters are available in both modes

--- a/config-engine-lite/configengine
+++ b/config-engine-lite/configengine
@@ -233,7 +233,7 @@ if __name__ == '__main__':
     parser.add_argument("--router", help="Name of your virtual router to configure, don't use together with --topo")
     parser.add_argument("--config", help="Template to apply to your router specified with --router")
     parser.add_argument("--type", help="Type of router specified with --router")
-    parser.add_argument("--attrs", help="Extra attributes exposed in your config template")
+    parser.add_argument("--attr", help="Add extra attribute exposed in your config template", action="append")
     parser.add_argument("--wait-for-boot", help="Retry connection until successful", default=False, action="store_true")
     parser.add_argument("--run", help="Apply configuration", default=False, action="store_true")
     parser.add_argument("--diff", help="Display configuration diff but don't commit", default=False, action="store_true")
@@ -289,7 +289,7 @@ if __name__ == '__main__':
         if args.attrs:
             attrs = {}
             try:
-                for entry in args.attrs.split(","):
+                for entry in args.attr:
                     pcs = entry.split("=")
                     attrs[pcs[0]] = pcs[1]
             except:


### PR DESCRIPTION
Now you can specify --attr key=value once for each attribute instead of providing a comma separated list in a single string.