### PR TITLE
fix cmd args so that each arg/value is its own list element.

### DIFF
--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -174,8 +174,12 @@ def run_topology(config, dry_run, with_trace=False):
         name = "%s%s" % (args.prefix, router)
         cmd = ["docker", "run", "--privileged", "-d",
                "--name", name,
-               "%svr-%s:%s %s %s" % (docker_registry, val["type"], val["version"], trace, val.get('run_args', ''))
-          ]
+               "%svr-%s:%s" % (docker_registry, val["type"], val["version"])
+        ]
+        if trace:
+            cmd.append(trace)
+        if 'run_args' in val:
+            cmd.extend(val["run_args"].split())
 
         output,_ = run_command(["docker", "inspect", "--format", "{{.State.Running}}", name])
         if output.strip() == "true":
@@ -188,10 +192,11 @@ def run_topology(config, dry_run, with_trace=False):
         name = "%svr-xcon" % args.prefix
         cmd = ["docker", "run", "--privileged", "-d", "--name", name]
 
-        cmd.extend(["--link %s%s:%s" % (args.prefix, vr, vr) for vr in sorted(config['routers'])])
+        for vr in sorted(config['routers']):
+            cmd.extend(["--link", "%s%s:%s" % (args.prefix, vr, vr)])
         cmd.append(docker_registry + "vr-xcon")
         cmd.append("--p2p")
-        cmd.extend([" %s%s/%s--%s%s/%s" % (args.prefix, link["left"]["router"],
+        cmd.extend(["%s%s/%s--%s%s/%s" % (args.prefix, link["left"]["router"],
                                            link["left"]["numeric"],
                                            args.prefix,
                                            link["right"]["router"],


### PR DESCRIPTION
subprocess.Popen requires either a single string or a list of args. topomachine is using a mix of a list of args and strings containing multiple args. this is causing the starting of containers to fail. this patch makes each arg its own list element.