### PR TITLE
Add support for `as-path` attribute for prefix.

### DIFF
--- a/vr-bgp/README.md
+++ b/vr-bgp/README.md
@@ -41,6 +41,92 @@ a time which might seem tedious at first but it also simplifies things a lot as
 we can key information merely on bgp speaker rather than on individual
 neighbors.
 
+API
+---
+The vr-bgp API is a very simple RESTful API running by default on port 5000, exposing three endpoints:
+* `GET http://docker-ip:5000/neighbors`: lists all configured neighbors and connection states
+* `GET http://docker-ip:5000/received`: lists all received prefixes by address family and their attributes
+* `POST http://docker-ip:5000/announce`: announces the prefixes specified in the body of the request, with optional attributes
+
+### `GET /neighbors`
+```javascript
+{
+    "192.168.21.2": {
+        "state": "up",
+        "timestamp": "2017-05-31 07:42:06"
+    },
+    "2001:db8:5::21:2": {
+        "state": "up",
+        "timestamp": "2017-05-31 07:42:06"
+    }
+}
+```
+
+The example shows a vr-bgp speaker configured with two neighbors. Connections to both neighbors are established.
+
+### `GET /received`
+```javascript
+{
+    "ipv4 unicast": {
+        "22.0.0.0/24": {
+            "as-path": [
+                2792,
+                22
+            ],
+            "community": [
+                [
+                    2792,
+                    10300
+                ],
+                [
+                    2792,
+                    11276
+                ]
+            ],
+            "confederation-path": [],
+            "origin": "igp"
+        }
+    },
+    "ipv6 unicast": {
+        "2001:11::/64": {
+            "as-path": [
+                2792,
+                11
+            ],
+            "community": [
+                [
+                    11,
+                    1234
+                ]
+            ],
+            "confederation-path": [],
+            "origin": "igp"
+        }
+    }
+}
+```
+
+The example shows two received prefixes for IPv4 and IPv4 address family with all attributes.
+Note that community string `2792:10300` is broken down into a list of integers `[2792, 10300]`.
+
+### `POST /announce`
+```javascript
+[
+    { "prefix": "21.0.0.0/24" },
+    { "prefix": "21.1.0.0/24", "community": ["2792:10300"]},
+    { "prefix": "21.2.0.0/24", "as-path": [21, 65000] },
+    { "prefix": "21.3.0.0/24", "med": 100 }
+]
+```
+
+The example shows announcement configuration for four prefixes. By default, all prefixes originate
+in the local AS (21 in this example).
+
+Additional attributes exposed through the API are:
+* `community`: set any number of communities by providing a list of strings `["x:y", "w:z"]`
+* `as-path`: override the default as-path (local-as) by providing a list of integers `[21, 65000]`
+* `med`: set multi-exit discriminator (MED) attribute to an integer value
+
 Example
 -------
 See the example directory for a full blown example of vr-bgp in action to

--- a/vr-bgp/bgpapi.py
+++ b/vr-bgp/bgpapi.py
@@ -33,6 +33,8 @@ def announce():
             command += " community [" + " ".join(route['community']) + "]"
         if 'med' in route:
             command += " med " + str(route['med'])
+        if 'as-path' in route:
+            command += " as-path [" + " ".join([str(x) for x in route['as-path']]) + "]"
         sys.stdout.write('%s\n' % command)
         sys.stdout.flush()
 


### PR DESCRIPTION
This adds support for defining a custom as-path for announced prefix, allowing us to create a fake transit peer. If omitted, the default value for this attribute is the local AS.

Example prefix announced from AS 21, originating from AS 1234 `{ 'prefix': '21.1.0.0/24', 'as-path': [21, 1234] }`.