### PR TITLE
Add neighbor listen by default

### DIFF
--- a/vr-bgp/exabgp.conf.tpl
+++ b/vr-bgp/exabgp.conf.tpl
@@ -28,6 +28,7 @@ group test {
         {%- if config.MD5 %}
         md5 "{{config.MD5}}";
         {%- endif %}
+        listen 179;
     }
 {%- endif %}
 {%- if config.IPV6_NEIGHBOR %}
@@ -42,6 +43,7 @@ group test {
         {%- if config.MD5 %}
         md5 "{{config.MD5}}";
         {%- endif %}
+        listen 179;
     }
 {%- endif %}
 }

--- a/vr-bgp/vr-bgp.py
+++ b/vr-bgp/vr-bgp.py
@@ -168,4 +168,8 @@ if __name__ == '__main__':
     # start exabgp
     exap = subprocess.Popen(["exabgp", "/exabgp.conf"])
     while True:
+        if exap.poll() == 0:
+            print("exabgp stopped, restarting in 2s")
+            time.sleep(2)
+            exap = subprocess.Popen(["exabgp", "/exabgp.conf"])
         time.sleep(1)


### PR DESCRIPTION
This MR adds a default `listen` statement to exabgp configuration.

For easier testing during development (especially when connecting vr-bgp instances back-to-back), it is useful to have vr-bgp instances listen for incoming connections on 179/TCP as well.

Additionally, this MR fixes parsing of updates exchanged between two vr-bgp instances directly connected.