### PR TITLE
Juniper vSRX

### DIFF
--- a/vsrx/Makefile
+++ b/vsrx/Makefile
@@ -1,0 +1,12 @@
+VENDOR=Juniper
+NAME=vSRX
+IMAGE_FORMAT=qcow
+IMAGE_GLOB=*.qcow2
+IMAGE=ffp-12.1X47-D15.4-packetmode.qcow2
+
+# match versions like:
+# 12.1X47-D15.4
+VERSION=$(shell echo $(IMAGE) | cut -d - -f2,3)
+
+-include ../makefile-sanity.include
+-include ../makefile.include

--- a/vsrx/README.md
+++ b/vsrx/README.md
@@ -1,0 +1,36 @@
+vrnetlab / Juniper vSRX
+==================================
+This is the vrnetlab docker image for Juniper vSRX.
+
+
+Building the docker image
+-------------------------
+The image can be downloaded automatically using ```./get-vsrx.sh```. The script will download the official Juniper Vagrant box (216 MB), uncompress it and convert the vSRX image to a QCOW2 format.
+Run ```make docker-image``` to build the docker image.
+
+Tested booting and responding to SSH:
+ * ffp-12.1X47-D15.4-packetmode.qcow2   MD5:692628eb87e067db33459a0030ec81b0
+
+Usage
+-----
+```
+docker run -d --privileged --name my-vsrx-box vr-vsrx:12.1X47-D15.4
+```
+
+
+System requirements
+-------------------
+CPU: 2 core
+
+RAM: 2GB
+
+Disk: <1GB
+
+https://www.juniper.net/documentation/en_US/firefly12.1x46-d10/topics/reference/general/security-virtual-perimeter-system-requirement-with-kvm.html
+
+
+FAQ - Frequently or Unfrequently Asked Questions
+-------------------------------------------------
+##### Q: Has this been extensively tested?
+A: Nope. It starts and you can connect to it. Take it for a spin and provide
+some feedback :-)

--- a/vsrx/docker/Dockerfile
+++ b/vsrx/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:stable
+MAINTAINER Kristian Larsson <kristian@spritelink.net>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+ && apt-get upgrade -qy \
+ && apt-get install -y \
+    bridge-utils \
+    iproute2 \
+    python3-ipy \
+    socat \
+    qemu-kvm \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+COPY $IMAGE* /
+COPY *.py /
+
+EXPOSE 22 830 5000 10000-10099
+HEALTHCHECK CMD ["/healthcheck.py"]
+ENTRYPOINT ["/launch.py"]

--- a/vsrx/docker/launch.py
+++ b/vsrx/docker/launch.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+import datetime
+import logging
+import os
+import re
+import signal
+import sys
+
+import vrnetlab
+
+def handle_SIGCHLD(signal, frame):
+    os.waitpid(-1, os.WNOHANG)
+
+def handle_SIGTERM(signal, frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+logging.Logger.trace = trace
+
+class VSRX_vm(vrnetlab.VM):
+    def __init__(self, username, password):
+        for e in os.listdir("/"):
+            if re.search(".qcow2$", e):
+                disk_image = "/" + e
+        super(VSRX_vm, self).__init__(username, password, disk_image=disk_image, ram=2048)
+        self.qemu_args.extend(["-smp", "2"])
+        self.nic_type = "virtio-net-pci"
+        self.num_nics = 10
+
+    def bootstrap_spin(self):
+        """ This function should be called periodically to do work.
+        """
+
+        if self.spins > 300:
+            # too many spins with no result ->  give up
+            self.stop()
+            self.start()
+            return
+
+        (ridx, match, res) = self.tn.expect([b"login:"], 1)
+        if match: # got a match!
+            if ridx == 0: # login
+                self.logger.info("VM started")
+
+                # Login
+                self.wait_write("\r", None)
+                self.wait_write("root", wait="login:")
+                self.wait_write("Juniper", wait="Password:")
+                self.wait_write("", wait="root@vsrx%")
+                self.logger.info("Login completed")
+
+                # run main config!
+                self.bootstrap_config()
+                # close telnet connection
+                self.tn.close()
+                # startup time?
+                startup_time = datetime.datetime.now() - self.start_time
+                self.logger.info("Startup complete in: %s" % startup_time)
+                # mark as running
+                self.running = True
+                return
+
+        # no match, if we saw some output from the router it's probably
+        # booting, so let's give it some more time
+        if res != b'':
+            self.logger.trace("OUTPUT: %s" % res.decode())
+            # reset spins if we saw some output
+            self.spins = 0
+
+        self.spins += 1
+
+        return
+
+    def bootstrap_config(self):
+        """ Do the actual bootstrap config
+        """
+        self.logger.info("applying bootstrap configuration")
+        self.wait_write("cli", "%")
+        self.wait_write("configure", ">")
+        self.wait_write("set system services ssh", "#")
+        self.wait_write("set system services netconf ssh", "#")
+        self.wait_write("delete system login user vagrant", "#")
+        self.wait_write("set system login user %s class super-user authentication plain-text-password" % ( self.username ), "#")
+        self.wait_write(self.password, "New password:")
+        self.wait_write(self.password, "Retype new password:")
+        self.wait_write("set system root-authentication plain-text-password", "#")
+        self.wait_write(self.password, "New password:")
+        self.wait_write(self.password, "Retype new password:")
+        self.wait_write("delete interfaces ge-0/0/0", "#")
+        self.wait_write("set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.15/24", "#")
+        self.wait_write("commit", "#")
+        self.wait_write("quit", "#")
+        self.logger.info("completed bootstrap configuration")
+
+class VSRX(vrnetlab.VR):
+    def __init__(self, username, password):
+        super(VSRX, self).__init__(username, password)
+        self.vms = [ VSRX_vm(username, password) ]
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default='vrnetlab', help='Username')
+    parser.add_argument('--password', default='VR-netlab9', help='Password')
+    args = parser.parse_args()
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    vr = VSRX(args.username, args.password)
+    vr.start()

--- a/vsrx/get-vsrx.sh
+++ b/vsrx/get-vsrx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE=$(ls temp/ffp*)
+IMAGE=$(ls temp/ffp* >/dev/null 2>&1)
 
 if [ ! -f temp/*.qcow2 ]; then
 

--- a/vsrx/get-vsrx.sh
+++ b/vsrx/get-vsrx.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+IMAGE=$(ls temp/ffp*)
+
+if [ ! -f temp/*.qcow2 ]; then
+
+  echo -e "Creating temp directory\n"
+  mkdir -p temp
+
+  echo -e "Downloading file\n"
+  wget -nc -O temp/virtualbox.box https://atlas.hashicorp.com/juniper/boxes/ffp-12.1X47-D15.4-packetmode/versions/0.5.0/providers/virtualbox.box
+
+  echo -e "Extracting Vagrant Box\n"
+  tar -xf temp/virtualbox.box -C temp
+
+  echo -e "Converting VMDK to QCOW2\n"
+  qemu-img convert -f vmdk -O qcow2 temp/packer-virtualbox-ovf-1427461878-disk1.vmdk temp/ffp-12.1X47-D15.4-packetmode.qcow2
+
+  echo -e "Copy QCOW2 image to main folder\n"
+  cp temp/*.qcow2 .
+
+else
+
+  echo "Image $IMAGE exists. Exiting."
+
+fi


### PR DESCRIPTION
Hi,

Ref. https://github.com/plajjan/vrnetlab/issues/133

Here's a working Juniper vSRX launcher. Added a shell script that downloads the public Juniper firefly Vagrant box and extracts the VMDK.

Let me know what you think :-)

 - Fredrik


```
# ./get-vsrx.sh

Creating temp directory

Downloading file

--2017-06-16 20:11:59--  https://atlas.hashicorp.com/juniper/boxes/ffp-12.1X47-D15.4-packetmode/versions/0.5.0/providers/virtualbox.box
Resolving atlas.hashicorp.com (atlas.hashicorp.com)... 52.200.255.5, 52.55.203.197, 52.206.86.0
Connecting to atlas.hashicorp.com (atlas.hashicorp.com)|52.200.255.5|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://archivist.hashicorp.com/v1/object/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJib3hlcy82MmUzNzkwMy05YWRkLTQ2ZDQtYjgyYS00YmE1YjU1M2YzNDIiLCJtb2RlIjoiciIsImV4cGlyZSI6MTQ5NzY3MjcyMH0.bGDzrAiHXGNv7HOrBSqxfaCvyjFtp9ceUrUCf5_lPps [following]
--2017-06-16 20:12:00--  https://archivist.hashicorp.com/v1/object/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJib3hlcy82MmUzNzkwMy05YWRkLTQ2ZDQtYjgyYS00YmE1YjU1M2YzNDIiLCJtb2RlIjoiciIsImV4cGlyZSI6MTQ5NzY3MjcyMH0.bGDzrAiHXGNv7HOrBSqxfaCvyjFtp9ceUrUCf5_lPps
Resolving archivist.hashicorp.com (archivist.hashicorp.com)... 52.205.53.12, 52.6.196.97, 34.226.19.134, ...
Connecting to archivist.hashicorp.com (archivist.hashicorp.com)|52.205.53.12|:443... connected.
HTTP request sent, awaiting response... 307 Temporary Redirect
Location: https://hc-prod-storagelocker.s3.amazonaws.com/boxes/62e37903-9add-46d4-b82a-4ba5b553f342?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJBKZ6DNPERBCPYKQ%2F20170616%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20170616T201200Z&X-Amz-Expires=60&X-Amz-SignedHeaders=host&X-Amz-Signature=c3ba08fa7c04b4720cf60532e8bede3ea1da4830fb6f40ebccf137edb516dc8f [following]
--2017-06-16 20:12:00--  https://hc-prod-storagelocker.s3.amazonaws.com/boxes/62e37903-9add-46d4-b82a-4ba5b553f342?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJBKZ6DNPERBCPYKQ%2F20170616%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20170616T201200Z&X-Amz-Expires=60&X-Amz-SignedHeaders=host&X-Amz-Signature=c3ba08fa7c04b4720cf60532e8bede3ea1da4830fb6f40ebccf137edb516dc8f
Resolving hc-prod-storagelocker.s3.amazonaws.com (hc-prod-storagelocker.s3.amazonaws.com)... 54.231.121.67
Connecting to hc-prod-storagelocker.s3.amazonaws.com (hc-prod-storagelocker.s3.amazonaws.com)|54.231.121.67|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 225834587 (215M) [application/octet-stream]
Saving to: ‘temp/virtualbox.box’

temp/virtualbox.box   100%[========================>] 215.37M  26.5MB/s   in 14s

2017-06-16 20:12:15 (15.3 MB/s) - ‘temp/virtualbox.box’ saved [225834587/225834587]

Extracting Vagrant Box

Converting VMDK to QCOW2

Copy QCOW2 image to main folder



# make docker-image; docker run -i -t --privileged vr-vsrx:12.1X47-D15.4 --trace
for IMAGE in ffp-12.1X47-D15.4-packetmode.qcow2; do \
	echo "Making $IMAGE"; \
	make IMAGE=$IMAGE docker-build; \
done
Making ffp-12.1X47-D15.4-packetmode.qcow2
make[1]: Entering directory '/mnt/sda1/vrnetlab/vsrx'
rm -f docker/*.qcow2* docker/*.tgz* docker/*.vmdk* docker/*.iso
Building docker image using ffp-12.1X47-D15.4-packetmode.qcow2 as vr-vsrx:12.1X47-D15.4
cp ../common/* docker/
cp ffp-12.1X47-D15.4-packetmode.qcow2* docker/
(cd docker; docker build --build-arg http_proxy= --build-arg https_proxy= --build-arg IMAGE=ffp-12.1X47-D15.4-packetmode.qcow2 -t vr-vsrx:12.1X47-D15.4 .)
Sending build context to Docker daemon   274 MB
Step 1/10 : FROM debian:stable
 ---> 954a3003e6c1
Step 2/10 : MAINTAINER Kristian Larsson <kristian@spritelink.net>
 ---> Using cache
 ---> 7e3596a3e4cd
Step 3/10 : ENV DEBIAN_FRONTEND noninteractive
 ---> Using cache
 ---> 6057dd083294
Step 4/10 : RUN apt-get update -qy  && apt-get upgrade -qy  && apt-get install -y     bridge-utils     iproute2     python3-ipy     socat     qemu-kvm  && rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 84db6e810d38
Step 5/10 : ARG IMAGE
 ---> Using cache
 ---> 427d2222384e
Step 6/10 : COPY $IMAGE* /
 ---> Using cache
 ---> 84c2735f8ece
Step 7/10 : COPY *.py /
 ---> Using cache
 ---> 18e76fc29622
Step 8/10 : EXPOSE 22 830 5000 10000-10099
 ---> Using cache
 ---> 3c6b44055dce
Step 9/10 : HEALTHCHECK CMD /healthcheck.py
 ---> Using cache
 ---> 40f86c0f14f0
Step 10/10 : ENTRYPOINT /launch.py
 ---> Using cache
 ---> d1b044a8dddd
Successfully built d1b044a8dddd
make[1]: Leaving directory '/mnt/sda1/vrnetlab/vsrx'
2017-06-16 20:12:49,198: vrnetlab   DEBUG    Starting vrnetlab VSRX
2017-06-16 20:12:49,199: vrnetlab   DEBUG    VMs: [<__main__.VSRX_vm object at 0x7f3781488160>]
2017-06-16 20:12:49,202: vrnetlab   DEBUG    VM not started; starting!
2017-06-16 20:12:49,203: vrnetlab   INFO     Starting VSRX_vm
2017-06-16 20:12:49,204: vrnetlab   DEBUG    ['qemu-system-x86_64', '-enable-kvm', '-display', 'none', '-machine', 'pc', '-monitor', 'tcp:0.0.0.0:4000,server,nowait', '-m', '2048', '-serial', 'telnet:0.0.0.0:5000,server,nowait', '-drive', 'if=ide,file=/ffp-12.1X47-D15.4-packetmode.qcow2', '-smp', '2', '-device', 'pci-bridge,chassis_nr=1,id=pci.1', '-device', 'virtio-net-pci,netdev=p00,mac=52:54:00:02:63:00', '-netdev', 'user,id=p00,net=10.0.0.0/24,tftp=/tftpboot,hostfwd=tcp::2022-10.0.0.15:22,hostfwd=tcp::2830-10.0.0.15:830', '-device', 'virtio-net-pci,netdev=p01,mac=52:54:00:e6:4d:01,bus=pci.1,addr=0x2', '-netdev', 'socket,id=p01,listen=:10001', '-device', 'virtio-net-pci,netdev=p02,mac=52:54:00:f9:12:02,bus=pci.1,addr=0x3', '-netdev', 'socket,id=p02,listen=:10002', '-device', 'virtio-net-pci,netdev=p03,mac=52:54:00:ad:8b:03,bus=pci.1,addr=0x4', '-netdev', 'socket,id=p03,listen=:10003', '-device', 'virtio-net-pci,netdev=p04,mac=52:54:00:94:96:04,bus=pci.1,addr=0x5', '-netdev', 'socket,id=p04,listen=:10004', '-device', 'virtio-net-pci,netdev=p05,mac=52:54:00:bf:14:05,bus=pci.1,addr=0x6', '-netdev', 'socket,id=p05,listen=:10005', '-device', 'virtio-net-pci,netdev=p06,mac=52:54:00:4c:7a:06,bus=pci.1,addr=0x7', '-netdev', 'socket,id=p06,listen=:10006', '-device', 'virtio-net-pci,netdev=p07,mac=52:54:00:aa:8e:07,bus=pci.1,addr=0x8', '-netdev', 'socket,id=p07,listen=:10007', '-device', 'virtio-net-pci,netdev=p08,mac=52:54:00:d4:98:08,bus=pci.1,addr=0x9', '-netdev', 'socket,id=p08,listen=:10008', '-device', 'virtio-net-pci,netdev=p09,mac=52:54:00:dd:df:09,bus=pci.1,addr=0xa', '-netdev', 'socket,id=p09,listen=:10009', '-device', 'virtio-net-pci,netdev=p10,mac=52:54:00:df:4c:0a,bus=pci.1,addr=0xb', '-netdev', 'socket,id=p10,listen=:10010']
2017-06-16 20:12:55,220: launch     TRACE    OUTPUT: Consoles: serial port
BIOS drive A: is disk0
BIOS drive C: is disk1
BIOS 639kB/2096000kB available memory

FreeBSD/i386 bootstrap loader, Revision 1.2
(builder@chamuth.juniper.net, Wed Nov 12 00:27:51 UTC 2014)
Loading /boot/defaults/loader.conf
-
2017-06-16 20:12:57,223: launch     TRACE    OUTPUT: /kernel text=0x985330 -
2017-06-16 20:12:59,225: launch     TRACE    OUTPUT: -
2017-06-16 20:13:01,227: launch     TRACE    OUTPUT: |
2017-06-16 20:13:03,230: launch     TRACE    OUTPUT: data=0x538b0+0x10208c syms=[0x4+0xa1c10+0x4+0xe76b3/
2017-06-16 20:13:05,233: launch     TRACE    OUTPUT: ]
/boot/modules/if_em.ko text=0x15404 data=0x79c+0x14 -
/boot/modules/libmbpool.ko text=0xd9c data=0x100
/boot/modules/if_em_vjx.ko text=0xb94c data=0x600+0x204 -
/boot/modules/virtio.ko text=0x21f8 data=0x1f8 syms=[0x4+0x7e0+0x4+0x972]
/boot/modules/virtio_pci.ko text=0x2e98 data=0x208+0x8 syms=[0x4+0x8f0+0x4+0xb22]
2017-06-16 20:13:07,236: launch     TRACE    OUTPUT:
/boot/modules/virtio_blk.ko text=0x2a08 data=0x1f0+0xc syms=[0x4+0x960+0x4+0xa0f]
/boot/modules/if_vtnet.ko text=0x6004 data=0x37c+0x10 syms=[0x4+0xde0+0x4+0xf0f]
/boot/modules/if_vtnet_vsrx.ko text=0x1f44 data=0x480+0x304 syms=[0x4+0x820+0x4+0xacb]


Hit [Enter] to boot immediately, or space bar for command prompt.
Booting [/kernel]...
platform_early_bootinit: Early Boot Initialization
GDB: debug ports: sio
GDB: current port: sio
KDB: debugger backends: ddb gdb
KDB: current backend: ddb

2017-06-16 20:13:15,246: launch     TRACE    OUTPUT: Copyright (c) 1996-2014, Juniper Networks, Inc.
All rights reserved.
Copyright (c) 1992-2006 The FreeBSD Project.
Copyright (c) 1979, 1980, 1983, 1986, 1988, 1989, 1991, 1992, 1993, 1994
	The Regents of the University of California. All rights reserved.
JUNOS 12.1X47-D15.4 #0: 2014-11-12 02:13:59 UTC
    builder@chamuth.juniper.net:/volume/build/junos/12.1/service/12.1X47-D15.4/obj-i386/junos/bsd/kernels/VSRX/kernel

2017-06-16 20:13:17,249: launch     TRACE    OUTPUT: acpi_alloc_wakeup_handler: can't alloc wake memory
ACPI APIC Table: <BOCHS  BXPCAPIC>

2017-06-16 20:13:19,252: launch     TRACE    OUTPUT: Timecounter "i8254" frequency 1193182 Hz quality 0
CPU: QEMU Virtual CPU version 2.1.2 (2394.01-MHz 686-class CPU)
  Origin = "GenuineIntel"  Id = 0x663  Stepping = 3
  Features=0x783fbfd<FPU,DE,PSE,TSC,MSR,PAE,MCE,CX8,APIC,SEP,MTRR,PGE,MCA,CMOV,PAT,PSE36,MMX,FXSR,SSE,SSE2>
  Features2=0x80a02001<SSE3,CX16,x2APIC,POPCNT,<b31>>
  AMD Features=0x20100800<SYSCALL,NX,LM>
  AMD Features2=0x1<LAHF>
real memory  = 2147352576 (2047 MB)
avail memory = 1146814464 (1093 MB)
FreeBSD/SMP: Multiprocessor System Detected: 2 CPUs
 cpu0 (BSP): APIC ID:  0
 cpu1 (AP): APIC ID:  1
ioapic0 <Version 1.1> irqs 0-23 on motherboard
netisr_init: !debug_mpsafenet, forcing maxthreads from 2 to 1
Initializing VSRX platform properties ..
acpi0: <BOCHS BXPCRSDT> on motherboard
acpi0: Power Button (fixed)
Timecounter "ACPI-safe" frequency 3579545 Hz quality 1000
acpi_timer0: <24-bit timer at 3.579545MHz> port 0x608-0x60b on acpi0
pcib0: <ACPI Host-PCI bridge> port 0xcf8-0xcff on acpi0

2017-06-16 20:13:21,256: launch     TRACE    OUTPUT: pci0: <ACPI PCI bus> on pcib0
isab0: <PCI-ISA bridge> at device 1.0 on pci0
isa0: <ISA bus> on isab0
atapci0: <Intel PIIX3 WDMA2 controller> port 0x1f0-0x1f7,0x3f6,0x170-0x177,0x376,0xd020-0xd02f at device 1.1 on pci0
ata0: <ATA channel 0> on atapci0
ata1: <ATA channel 1> on atapci0
smb0: <Intel 82371AB SMB controller> irq 9 at device 1.3 on pci0
pci0: <display, VGA> at device 2.0 (no driver attached)
pcib1: <ACPI PCI-PCI bridge> mem 0xfea51000-0xfea510ff irq 11 at device 3.0 on pci0
pci1: <ACPI PCI bus> on pcib1
virtio_pci0: <VirtIO PCI Network adapter> port 0xc000-0xc01f mem 0xfe880000-0xfe880fff irq 10 at device 2.0 on pci1
em0: <VirtIO Networking Adapter> on virtio_pci0
virtio_pci0: host features: 0x79bf8064 <EventIdx,RingIndirect,0x8000000,NotifyOnEmpty,0x800000,0x200000,RxModeExtra,VLanFilter,RxMode,ControlVq,Status,MrgRxBuf,TxAllGSO,MacAddress,0x4>
virtio_pci0: negotiated features: 0x78020 <RxMode,ControlVq,Status,MrgRxBuf,MacAddress>
virtio_pci1: <VirtIO PCI Network adapter> port 0xc020-0xc03f mem 0xfe881000-0xfe881fff irq 10 at device 3.0 on pci1
em1: <VirtIO Networking Adapter> on virtio_pci1
virtio_pci1: host features: 0x79bf8064 <EventIdx,RingIndirect,0x8000000,NotifyOnEmpty,0x800000,0x200000,RxModeExtra,VLanFilter,RxMode,ControlVq,Status,MrgRxBuf,TxAllGSO,MacAddress,0x4>
virtio_pci1: negotiated features: 0x78020 <RxMode,ControlVq,Status,MrgRxBuf,MacAddress>
virtio_pci2: <VirtIO PCI Network adapter> port 0xc040-0xc05f mem 0xfe882000-0xfe882fff irq 11 at device 4.0 on pci1
em2: <VirtIO Networking Adapter> on virtio_pci2
virtio_pci2: host features: 0x79bf8064 <EventIdx,RingIndirect,0x8000000,NotifyOnEmpty,0x800000,0x200000,RxModeExtra,VLanFilter,RxMode,ControlVq,Status,MrgRxBuf,TxAllGSO,MacAddress,0x4>
virtio_pci2: negotiated features: 0x78020 <RxMode,ControlVq,Status,MrgRxBuf,MacAddress>
virtio_pci3: <VirtIO PCI Network adapter> port 0xc060-0xc07f mem 0xfe883000-0xfe883fff irq 11 at device 5.0 on pci1
em3: <VirtIO Networking Adapter> on virtio_pci3
virtio_pci3: host features: 0x79bf8064 <EventIdx,RingIndirect,0x8000000,NotifyOnEmpty,0x800000,0x200000,RxModeExtra,VLanFilter,RxMode,ControlVq,Status,MrgRxBuf,TxAllGSO,MacAddress,0x4>
virtio_pci3: negotiated features: 0x78020 <RxMode,ControlVq,Status,MrgRxBuf,MacAddress>
virtio_pci4: <VirtIO PCI Network adapter> port 0xc080-0xc09f mem 0xfe884000-0xfe884fff irq 10 at device 6.0 on pci1
em4: <VirtIO Networking Adapter> on virtio_pci4
virtio_pci4: host features: 0x79bf8064 <EventIdx,RingIndirect,0x8000000,NotifyOnEmpty,0x800000,0x200000,RxModeExtra,VLanFilter,RxMode,ControlVq,Status,MrgRxBuf,TxAllGSO,MacAddress,0x4>
virtio_pci4: negotiated features: 0x78020 <RxMode,ControlVq,Status,MrgRxBuf,MacAddress>
virtio_pci5: <VirtIO PCI Network adapter> port 0xc0a0-0xc0bf mem 0xfe885000-0xfe885fff irq 10 at device 7.0 on pci1
em5: <VirtIO Networking Adapter> on virtio_pci5
virtio_pci5: host features: 0x79bf8064 <EventIdx,RingIndirect,0x8000000,NotifyOnEmpty,0x800000,0x200000,RxModeExtra,VLanFilter,RxMode,ControlVq,Status,MrgRxBuf,TxAllGSO,MacAddress,0x4>
virtio_pci5: negotiated features: 0x78020 <RxMode,ControlVq,Status,MrgRxBuf,MacAddress>
virtio_pci6: <VirtIO PCI Network adapter> port 0xc0c0-0xc0df mem 0xfe886000-0xfe886fff irq 11 at device 8.0 on pci1
em6: <VirtIO Networking Adapter> on virtio_pci6
virtio_pci6: host features: 0x79bf8064 <EventIdx,RingIndirect,0x8000000,NotifyOnEmpty,0x800000,0x200000,RxModeExtra,VLanFilter,RxMode,ControlVq,Status,MrgRxBuf,TxAllGSO,MacAddress,0x4>
virtio_pci6: negotiated features: 0x78020 <RxMode,ControlVq,Status,MrgRxBuf,MacAddress>
virtio_pci7: <VirtIO PCI Network adapter> port 0xc0e0-0xc0ff mem 0xfe887000-0xfe887fff irq 11 at device 9.0 on pci1
em7: <VirtIO Networking Adapter> on virtio_pci7
virtio_pci7: host features: 0x79bf8064 <EventIdx,RingIndirect,0x8000000,NotifyOnEmpty,0x800000,0x200000,RxModeExtra,VLanFilter,RxMode,ControlVq,Status,MrgRxBuf,TxAllGSO,MacAddress,0x4>
virtio_pci7: negotiated features: 0x78020 <RxMode,ControlVq,Status,MrgRxBuf,MacAddress>
virtio_pci8: <VirtIO PCI Network adapter> port 0xc100-0xc11f mem 0xfe888000-0xfe888fff irq 10 at device 10.0 on pci1
em8: <VirtIO Networking Adapter> on virtio_pci8
virtio_pci8: host features: 0x79bf8064 <EventIdx,RingIndirect,0x8000000,NotifyOnEmpty,0x800000,0x200000,RxModeExtra,VLanFilter,RxMode,ControlVq,Status,MrgRxBuf,TxAllGSO,MacAddress,0x4>
virtio_pci8: negotiated features: 0x78020 <RxMode,ControlVq,Status,MrgRxBuf,MacAddress>
virtio_pci9: <VirtIO PCI Network adapter> port 0xc120-0xc13f mem 0xfe889000-0xfe889fff irq 10 at device 11.0 on pci1
em9: <VirtIO Networking Adapter> on virtio_pci9
virtio_pci9: host features: 0x79bf8064 <EventIdx,RingIndirect,0x8000000,NotifyOnEmpty,0x800000,0x200000,RxModeExtra,VLanFilter,RxMode,ControlVq,Status,MrgRxBuf,TxAllGSO,MacAddress,0x4>
virtio_pci9: negotiated features: 0x78020 <RxMode,ControlVq,Status,MrgRxBuf,MacAddress>
virtio_pci10: <VirtIO PCI Network adapter> port 0xd000-0xd01f mem 0xfea52000-0xfea52fff irq 11 at device 4.0 on pci0
em10: <VirtIO Networking Adapter> on virtio_pci10
virtio_pci10: host features: 0x79bf8064 <EventIdx,RingIndirect,0x8000000,NotifyOnEmpty,0x800000,0x200000,RxModeExtra,VLanFilter,RxMode,ControlVq,Status,MrgRxBuf,TxAllGSO,MacAddress,0x4>
virtio_pci10: negotiated features: 0x78020 <RxMode,ControlVq,Status,MrgRxBuf,MacAddress>
cpu0: <ACPI CPU> on acpi0
cpu1: <ACPI CPU> on acpi0
atkbdc0: <Keyboard controller (i8042)> port 0x60,0x64 irq 1 on acpi0

2017-06-16 20:13:23,259: launch     TRACE    OUTPUT: atkbd0: <AT Keyboard> irq 1 on atkbdc0
kbd0 at atkbd0

2017-06-16 20:13:25,262: launch     TRACE    OUTPUT: psm0: <PS/2 Mouse> irq 12 on atkbdc0
psm0: model IntelliMouse Explorer, device ID 4
sio0: <16550A-compatible COM port> port 0x3f8-0x3ff irq 4 flags 0x90 on acpi0
sio0: type 16550A, console
orm0: <ISA Option ROM> at iomem 0xee800-0xeffff on isa0
vga0: <Generic ISA VGA> at port 0x3c0-0x3df iomem 0xa0000-0xbffff on isa0
sc0: <System console> at flags 0x100 on isa0
sc0: VGA <16 virtual consoles, flags=0x300>
sio1: configured irq 5 not in bitmap of probed irqs 0
sio1: port may not be enabled
sio2: configured irq 3 not in bitmap of probed irqs 0
sio2: port may not be enabled
sio3: configured irq 7 not in bitmap of probed irqs 0
sio3: port may not be enabled
Initializing product: 131 ..

2017-06-16 20:13:27,264: launch     TRACE    OUTPUT: ###PCB Group initialized for udppcbgroup
###PCB Group initialized for tcppcbgroup
ad0: Device does not support APM
ad0: 1844MB <QEMU HARDDISK 2.1.2> at ata0-master WDMA2
SMP: AP CPU #1 Launched!
Trying to mount root from ufs:/dev/ad0s1a
Attaching /cf/packages/junos via /dev/mdctl...
Mounted junos package on /dev/md0...

Automatic reboot in progress...

2017-06-16 20:13:29,268: launch     TRACE    OUTPUT: ** /dev/ad0s1a
FILE SYSTEM CLEAN; SKIPPING CHECKS
clean, 707962 free (26 frags, 176984 blocks, 0.0% fragmentation)
** /dev/bo0s1e
FILE SYSTEM CLEAN; SKIPPING CHECKS
clean, 102778 free (2 frags, 25694 blocks, 0.0% fragmentation)
Verified junos signed by PackageProduction_12_1_0
Verified jboot signed by PackageProduction_12_1_0

2017-06-16 20:13:37,278: launch     TRACE    OUTPUT: Verified junos-vsrx-12.1X47-D15.4-domestic signed by PackageProduction_12_1_0
Loading configuration ...

2017-06-16 20:14:03,312: launch     TRACE    OUTPUT: mgd: commit complete
Setting initial options: .
Starting optional daemons: .
Doing initial network setup:.
Initial interface configuration:
additional daemons: eventd.

2017-06-16 20:14:05,315: launch     TRACE    OUTPUT: Additional routing options:kern.module_path: /boot//kernel;/boot/modules -> /boot/modules;/modules/peertype;/modules/ifpfe_drv;/modules/platform;/modules;
kld netpfe drv: ifpfed_ism ifpfed_ml_ha ifpfed_ppeer ifpfed_st ifpfed_vtkld platform: fileassoc if_em if_em_vjx if_vtnet if_vtnet_vsrx virtio virtio_blk virtio_pcikld peertype: peertype_fwdd peertype_pfpc ipsec kld resrsv.
Doing additional network setup:.
Starting final network daemons:.
setting ldconfig path: /usr/lib /opt/lib
ldconfig: /opt/lib: ignoring directory not owned by root
starting standard daemons: cron.
Initial rc.i386 initialization:.

 Lock Manager
RDM Embedded 7 [04-Aug-2006] http://www.birdstep.com
Copyright (c) 1992-2006 Birdstep Technology, Inc.  All Rights Reserved.

Unix Domain sockets Lock manager
Lock manager 'lockmgr' started successfully.
Error: Profile database dictionary file missing.
Profile database initialized
Local package initialization:.
starting local daemons:set cores for group access
net.inet.ip.mcast_ttl: 1 -> 64
.
kern.securelevel: -1 -> 1
[: SeaBIOS1.7.5-20140531_083030-gandalfStandard: unexpected operator
Fri Jun 16 20:14:03 UTC 2017

2017-06-16 20:14:07,318: launch     TRACE    OUTPUT: Jun 16 20:14:03 init: service-deployment (PID 1202) started

2017-06-16 20:14:08,320: launch     INFO     VM started
2017-06-16 20:14:08,320: vrnetlab   DEBUG    writing to serial console:
2017-06-16 20:14:08,320: vrnetlab   TRACE    waiting for 'login:' on serial console
2017-06-16 20:14:08,349: vrnetlab   TRACE    read from serial console:

vsrx (ttyd0)

login:
2017-06-16 20:14:08,349: vrnetlab   DEBUG    writing to serial console: root
2017-06-16 20:14:08,349: vrnetlab   TRACE    waiting for 'Password:' on serial console
2017-06-16 20:14:09,680: vrnetlab   TRACE    read from serial console:  root
Password:
2017-06-16 20:14:09,680: vrnetlab   DEBUG    writing to serial console: Juniper
2017-06-16 20:14:09,681: vrnetlab   TRACE    waiting for 'root@vsrx%' on serial console
2017-06-16 20:14:19,715: vrnetlab   TRACE    read from serial console:

--- JUNOS 12.1X47-D15.4 built 2014-11-12 02:13:59 UTC
root@vsrx%
2017-06-16 20:14:19,716: vrnetlab   DEBUG    writing to serial console:
2017-06-16 20:14:19,716: launch     INFO     Login completed
2017-06-16 20:14:19,716: launch     INFO     applying bootstrap configuration
2017-06-16 20:14:19,716: vrnetlab   TRACE    waiting for '%' on serial console
2017-06-16 20:14:19,768: vrnetlab   TRACE    read from serial console:
root@vsrx%
2017-06-16 20:14:19,768: vrnetlab   DEBUG    writing to serial console: cli
2017-06-16 20:14:19,768: vrnetlab   TRACE    waiting for '>' on serial console
2017-06-16 20:14:21,100: vrnetlab   TRACE    read from serial console:  cli
root@vsrx>
2017-06-16 20:14:21,100: vrnetlab   DEBUG    writing to serial console: configure
2017-06-16 20:14:21,100: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-16 20:14:21,369: vrnetlab   TRACE    read from serial console:  configure
Entering configuration mode

[edit]
root@vsrx#
2017-06-16 20:14:21,370: vrnetlab   DEBUG    writing to serial console: set system services ssh
2017-06-16 20:14:21,370: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-16 20:14:21,448: vrnetlab   TRACE    read from serial console:  set system services ssh

[edit]
root@vsrx#
2017-06-16 20:14:21,448: vrnetlab   DEBUG    writing to serial console: set system services netconf ssh
2017-06-16 20:14:21,450: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-16 20:14:21,498: vrnetlab   TRACE    read from serial console:  set system services netconf ssh

[edit]
root@vsrx#
2017-06-16 20:14:21,498: vrnetlab   DEBUG    writing to serial console: delete system login user vagrant
2017-06-16 20:14:21,499: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-16 20:14:21,599: vrnetlab   TRACE    read from serial console:  delete system login user vagrant

[edit]
root@vsrx#
2017-06-16 20:14:21,599: vrnetlab   DEBUG    writing to serial console: set system login user vrnetlab class super-user authentication plain-text-password
2017-06-16 20:14:21,600: vrnetlab   TRACE    waiting for 'New password:' on serial console
2017-06-16 20:14:21,688: vrnetlab   TRACE    read from serial console:  set system loroot@vsrx# ...rnetlab class super-user authentication plain-text-password
New password:
2017-06-16 20:14:21,688: vrnetlab   DEBUG    writing to serial console: VR-netlab9
2017-06-16 20:14:21,689: vrnetlab   TRACE    waiting for 'Retype new password:' on serial console
2017-06-16 20:14:21,738: vrnetlab   TRACE    read from serial console:
Retype new password:
2017-06-16 20:14:21,738: vrnetlab   DEBUG    writing to serial console: VR-netlab9
2017-06-16 20:14:21,739: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-16 20:14:21,798: vrnetlab   TRACE    read from serial console:

[edit]
root@vsrx#
2017-06-16 20:14:21,798: vrnetlab   DEBUG    writing to serial console: set system root-authentication plain-text-password
2017-06-16 20:14:21,799: vrnetlab   TRACE    waiting for 'New password:' on serial console
2017-06-16 20:14:21,848: vrnetlab   TRACE    read from serial console:  set system root-authentication plain-text-password
New password:
2017-06-16 20:14:21,848: vrnetlab   DEBUG    writing to serial console: VR-netlab9
2017-06-16 20:14:21,849: vrnetlab   TRACE    waiting for 'Retype new password:' on serial console
2017-06-16 20:14:21,898: vrnetlab   TRACE    read from serial console:
Retype new password:
2017-06-16 20:14:21,898: vrnetlab   DEBUG    writing to serial console: VR-netlab9
2017-06-16 20:14:21,899: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-16 20:14:21,948: vrnetlab   TRACE    read from serial console:

[edit]
root@vsrx#
2017-06-16 20:14:21,948: vrnetlab   DEBUG    writing to serial console: delete interfaces ge-0/0/0
2017-06-16 20:14:21,949: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-16 20:14:22,119: vrnetlab   TRACE    read from serial console:  delete interfaces ge-0/0/0

[edit]
root@vsrx#
2017-06-16 20:14:22,120: vrnetlab   DEBUG    writing to serial console: set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.15/24
2017-06-16 20:14:22,120: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-16 20:14:22,194: vrnetlab   TRACE    read from serial console:  set interfaceroot@vsrx# unit 0 family inet address 10.0.0.15/24
2017-06-16 20:14:22,195: vrnetlab   DEBUG    writing to serial console: commit
2017-06-16 20:14:22,195: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-16 20:14:22,238: vrnetlab   TRACE    read from serial console:  ... unit 0 family inet address 10.0.0.15/24

[edit]
root@vsrx#
2017-06-16 20:14:22,238: vrnetlab   DEBUG    writing to serial console: quit
2017-06-16 20:14:22,239: launch     INFO     completed bootstrap configuration
2017-06-16 20:14:22,239: launch     INFO     Startup complete in: 0:01:33.036155
```