### PR TITLE
openwrt to the people

### DIFF
--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -1,0 +1,11 @@
+VENDOR=OpenWRT
+NAME=OpenWRT
+IMAGE_FORMAT=img
+IMAGE_GLOB=*.img
+
+# match versions like:
+# openwrt-15.05-x86-kvm_guest-combined-ext4.img
+VERSION=$(shell echo $(IMAGE) | cut -d - -f 2)
+
+-include ../makefile-sanity.include
+-include ../makefile.include

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -1,0 +1,32 @@
+vrnetlab / OpenWRT
+==================================
+This is the vrnetlab docker image for OpenWRT.
+
+Building the docker image
+-------------------------
+Download an image from openwrt.org https://downloads.openwrt.org/chaos_calmer/15.05.1/x86/kvm_guest/ . Gunzip the file and run `make docker-image`.
+
+As per OpenWRT defaults, `br-lan`(`eth0`) is the LAN interface and `eth1` the WAN interface.
+
+Tested booting and responding to SSH:
+* openwrt-15.05-x86-kvm_guest-combined-ext4.img   MD5:3d9b51a7e0cd728137318989a9fd35fb
+
+Usage
+-----
+```
+docker run -d --privileged --name openwrt1 vr-openwrt:15.05
+```
+
+System requirements
+-------------------
+CPU: 1 core
+
+RAM: 128 MB
+
+Disk: 256 MB
+
+FAQ - Frequently or Unfrequently Asked Questions
+-------------------------------------------------
+##### Q: Has this been extensively tested?
+A: Nope. It starts and you can connect to it. Take it for a spin and provide
+some feedback :-)

--- a/openwrt/docker/Dockerfile
+++ b/openwrt/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:stable
+MAINTAINER Kristian Larsson <kristian@spritelink.net>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+ && apt-get upgrade -qy \
+ && apt-get install -y \
+    bridge-utils \
+    iproute2 \
+    python3-ipy \
+    socat \
+    qemu-kvm \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+COPY $IMAGE* /
+COPY *.py /
+
+EXPOSE 22 80 830 5000 10000-10099
+HEALTHCHECK CMD ["/healthcheck.py"]
+ENTRYPOINT ["/launch.py"]

--- a/openwrt/docker/launch.py
+++ b/openwrt/docker/launch.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import datetime
+import logging
+import os
+import re
+import signal
+import sys
+import telnetlib
+
+import vrnetlab
+
+def handle_SIGCHLD(signal, frame):
+    os.waitpid(-1, os.WNOHANG)
+
+def handle_SIGTERM(signal, frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+logging.Logger.trace = trace
+
+class OpenWRT_vm(vrnetlab.VM):
+    def __init__(self, username, password):
+        for e in os.listdir("/"):
+            if re.search(".img$", e):
+                disk_image = "/" + e
+        super(OpenWRT_vm, self).__init__(username, password, disk_image=disk_image, ram=128)
+        self.nic_type = "virtio-net-pci"
+        self.num_nics = 1
+
+    def bootstrap_spin(self):
+        """ This function should be called periodically to do work.
+        """
+
+        if self.spins > 300:
+            # too many spins with no result ->  give up
+            self.stop()
+            self.start()
+            return
+
+        (ridx, match, res) = self.tn.expect([b"br-lan"], 1)
+        if match: # got a match!
+            if ridx == 0: # login
+                self.logger.debug("VM started")
+                # run main config!
+                self.bootstrap_config()
+                # close telnet connection
+                self.tn.close()
+                # startup time?
+                startup_time = datetime.datetime.now() - self.start_time
+                self.logger.info("Startup complete in: %s" % startup_time)
+                # mark as running
+                self.running = True
+                return
+
+        # no match, if we saw some output from the router it's probably
+        # booting, so let's give it some more time
+        if res != b'':
+            self.logger.trace("OUTPUT: %s" % res.decode())
+            # reset spins if we saw some output
+            self.spins = 0
+
+        self.spins += 1
+
+        return
+
+    def bootstrap_config(self):
+        """ Do the actual bootstrap config
+        """
+        self.logger.info("applying bootstrap configuration")
+        # Get a prompt
+        self.wait_write("\r", None)
+        # Configure interface
+        self.wait_write("ifconfig br-lan 10.0.0.15 netmask 255.255.255.0", "#")
+        # Set root password (ssh login prerequisite)
+        self.wait_write("passwd", "#")
+        self.wait_write(self.password, "New password:")
+        self.wait_write(self.password, "Retype password:")
+        # Create vrnetlab user
+        self.wait_write("echo '%s:x:501:501:%s:/home/%s:/bin/ash' >> /etc/passwd" %(self.username, self.username, self.username), "#")
+        self.wait_write("passwd %s" %(self.username))
+        self.wait_write(self.password, "New password:")
+        self.wait_write(self.password, "Retype password:")
+        # Add user to root group
+        self.wait_write("sed -i '1d' /etc/group", "#")
+        self.wait_write("sed -i '1i root:x:0:%s' /etc/group" % (self.username))
+        # Create home dir
+        self.wait_write("mkdir -p /home/%s" %(self.username))
+        self.wait_write("chown %s /home/%s" %(self.username, self.username))
+        self.logger.info("completed bootstrap configuration")
+
+class OpenWRT(vrnetlab.VR):
+    def __init__(self, username, password):
+        super(OpenWRT, self).__init__(username, password)
+        self.vms = [ OpenWRT_vm(username, password) ]
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default='vrnetlab', help='Username')
+    parser.add_argument('--password', default='VR-netlab9', help='Password')
+    args = parser.parse_args()
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    vr = OpenWRT(args.username, args.password)
+    vr.start()


### PR DESCRIPTION
Hi,

Thought this one might be funny :-) 
OpenWRT is a cool platform, with https://www.gl-inet.com/ and such. Could use this to mimic "home devices" or whatnot.

What do you think, could this be of interest to people?

/Fredrik

SSH login:
```
# ssh vrnetlab@172.17.0.2
vrnetlab@172.17.0.2's password:


BusyBox v1.23.2 (2015-07-25 08:11:38 CEST) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 CHAOS CALMER (15.05, r46767)
 -----------------------------------------------------
  * 1 1/2 oz Gin            Shake with a glassful
  * 1/4 oz Triple Sec       of broken ice and pour
  * 3/4 oz Lime Juice       unstrained into a goblet.
  * 1 1/2 oz Orange Juice
  * 1 tsp. Grenadine Syrup
 -----------------------------------------------------
vrnetlab@OpenWrt:~$ id
uid=501(vrnetlab) gid=501 groups=0(root),501
vrnetlab@OpenWrt:~$ pwd
/home/vrnetlab
vrnetlab@OpenWrt:~$
```

Boot sequence (the box is possibly setting a startup time record here - under 16 seconds!):
```
# make docker-image; docker run -i -t --privileged vr-openwrt:15.05 --trace
for IMAGE in openwrt-15.05-x86-kvm_guest-combined-ext4.img; do \
	echo "Making $IMAGE"; \
	make IMAGE=$IMAGE docker-build; \
done
Making openwrt-15.05-x86-kvm_guest-combined-ext4.img
make[1]: Entering directory '/mnt/sda1/vrnetlab/openwrt'
rm -f docker/*.qcow2* docker/*.tgz* docker/*.vmdk* docker/*.iso
Building docker image using openwrt-15.05-x86-kvm_guest-combined-ext4.img as vr-openwrt:15.05
cp ../common/* docker/
cp openwrt-15.05-x86-kvm_guest-combined-ext4.img* docker/
(cd docker; docker build --build-arg http_proxy= --build-arg https_proxy= --build-arg IMAGE=openwrt-15.05-x86-kvm_guest-combined-ext4.img -t vr-openwrt:15.05 .)
Sending build context to Docker daemon 61.88 MB
Step 1/10 : FROM debian:stable
 ---> 954a3003e6c1
Step 2/10 : MAINTAINER Kristian Larsson <kristian@spritelink.net>
 ---> Using cache
 ---> 7e3596a3e4cd
Step 3/10 : ENV DEBIAN_FRONTEND noninteractive
 ---> Using cache
 ---> 6057dd083294
Step 4/10 : RUN apt-get update -qy  && apt-get upgrade -qy  && apt-get install -y     bridge-utils     iproute2     python3-ipy     socat     qemu-kvm  && rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 84db6e810d38
Step 5/10 : ARG IMAGE
 ---> Using cache
 ---> 427d2222384e
Step 6/10 : COPY $IMAGE* /
 ---> Using cache
 ---> 2dae6a948be3
Step 7/10 : COPY *.py /
 ---> Using cache
 ---> 2a0c7494dd6f
Step 8/10 : EXPOSE 22 80 830 5000 10000-10099
 ---> Using cache
 ---> 241f502e5ce7
Step 9/10 : HEALTHCHECK CMD /healthcheck.py
 ---> Using cache
 ---> 42d8ace9d9e8
Step 10/10 : ENTRYPOINT /launch.py
 ---> Using cache
2017-06-17 23:30:36,208: launch     TRACE    OUTPUT:
Successfully built 33129ca7190a
make[1]: Leaving directory '/mnt/sda1/vrnetlab/openwrt'
2017-06-17 23:30:28,179: vrnetlab   DEBUG    Starting vrnetlab OpenWRT
2017-06-17 23:30:28,180: vrnetlab   DEBUG    VMs: [<__main__.OpenWRT_vm object at 0x7f218704b0b8>]
2017-06-17 23:30:28,184: vrnetlab   DEBUG    VM not started; starting!
2017-06-17 23:30:28,185: vrnetlab   INFO     Starting OpenWRT_vm
2017-06-17 23:30:28,185: vrnetlab   DEBUG    ['qemu-system-x86_64', '-enable-kvm', '-display', 'none', '-machine', 'pc', '-monitor', 'tcp:0.0.0.0:4000,server,nowait', '-m', '128', '-serial', 'telnet:0.0.0.0:5000,server,nowait', '-drive', 'if=ide,file=/openwrt-15.05-x86-kvm_guest-combined-ext4.img', '-device', 'pci-bridge,chassis_nr=1,id=pci.1', '-device', 'virtio-net-pci,netdev=p00,mac=52:54:00:7d:23:00', '-netdev', 'user,id=p00,net=10.0.0.0/24,tftp=/tftpboot,hostfwd=tcp::2022-10.0.0.15:22,hostfwd=tcp::2830-10.0.0.15:830', '-device', 'virtio-net-pci,netdev=p01,mac=52:54:00:9f:b7:01,bus=pci.1,addr=0x2', '-netdev', 'socket,id=p01,listen=:10001']
   The highlighted entry will be executed automatically in 0s.
  Booting `OpenWrt'

[    0.000000] Linux version 3.18.20 (buildbot@builder1) (gcc version 4.8.3 (OpenWrt/Linaro GCC 4.8-2014.04 r46450) ) #1 Fri Sep 4 20:43:22 CEST 2015
[    0.000000] e820: BIOS-provided physical RAM map:
[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
[    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
[    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x0000000007fdffff] usable
[    0.000000] BIOS-e820: [mem 0x0000000007fe0000-0x0000000007ffffff] reserved
[    0.000000] BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
[    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
[    0.000000] Notice: NX (Execute Disable) protection cannot be enabled: non-PAE kernel!
[    0.000000] Hypervisor detected: KVM
[    0.000000] e820: last_pfn = 0x7fe0 max_arch_pfn = 0x100000
[    0.000000] found SMP MP-table at [mem 0x000f0ec0-0x000f0ecf] mapped at [c00f0ec0]
[    0.000000] init_memory_mapping: [mem 0x00000000-0x000fffff]
[    0.000000] init_memory_mapping: [mem 0x07800000-0x07bfffff]
[    0.000000] init_memory_mapping: [mem 0x00100000-0x077fffff]
[    0.000000] init_memory_mapping: [mem 0x07c00000-0x07fdffff]
[    0.000000] ACPI: Early table checksum verification disabled
[    0.000000] ACPI: RSDP 0x00000000000F0CE0 000014 (v00 BOCHS )
[    0.000000] ACPI: RSDT 0x0000000007FE1FA4 000034 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)
[    0.000000] ACPI: FACP 0x0000000007FE0B37 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)
[    0.000000] ACPI: DSDT 0x0000000007FE0040 000AF7 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)
[    0.000000] ACPI: FACS 0x0000000007FE0000 000040
[    0.000000] ACPI: SSDT 0x0000000007FE0BAB 001349 (v01 BOCHS  BXPCSSDT 00000001 BXPC 00000001)
[    0.000000] ACPI: APIC 0x0000000007FE1EF4 000078 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)
[    0.000000] ACPI: HPET 0x0000000007FE1F6C 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)
[    0.000000] 127MB LOWMEM available.
[    0.000000]   mapped low ram: 0 - 07fe0000
[    0.000000]   low ram: 0 - 07fe0000
[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
[    0.000000] kvm-clock: cpu 0, msr 0:7fdf001, primary cpu clock
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x00001000-0x00ffffff]
[    0.000000]   Normal   [mem 0x01000000-0x07fdffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x00001000-0x0009efff]
[    0.000000]   node   0: [mem 0x00100000-0x07fdffff]
[    0.000000] Initmem setup node 0 [mem 0x00001000-0x07fdffff]
[    0.000000] Using APIC driver default
[    0.000000] ACPI: PM-Timer IO Port: 0x608
[    0.000000] ACPI: LAPIC (acpi_id[0x00] lapic_id[0x00] enabled)
[    0.000000] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
[    0.000000] ACPI: IOAPIC (id[0x00] address[0xfec00000] gsi_base[0])
[    0.000000] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
[    0.000000] Using ACPI (MADT) for SMP configuration information
[    0.000000] ACPI: HPET id: 0x8086a201 base: 0xfed00000
[    0.000000] KVM setup async PF for cpu 0
[    0.000000] kvm-stealtime: cpu 0, msr 140ad80
[    0.000000] e820: [mem 0x08000000-0xfeffbfff] available for PCI devices
[    0.000000] Booting paravirtualized kernel on KVM
[    0.000000] Built 1 zonelists in Zone order, mobility grouping on.  Total pages: 32382
[    0.000000] Kernel command line: BOOT_IMAGE=/boot/vmlinuz root=PARTUUID=e6c13b07-02 rootfstype=ext4 rootwait console=tty0 console=ttyS0,115200n8 noinitrd
[    0.000000] PID hash table entries: 512 (order: -1, 2048 bytes)
[    0.000000] Dentry cache hash table entries: 16384 (order: 4, 65536 bytes)
[    0.000000] Inode-cache hash table entries: 8192 (order: 3, 32768 bytes)
[    0.000000] Initializing CPU#0
[    0.000000] Memory: 124464K/130552K available (3372K kernel code, 214K rwdata, 668K rodata, 276K init, 252K bss, 6088K reserved)
[    0.000000] virtual kernel memory layout:
[    0.000000]     fixmap  : 0xfffa2000 - 0xfffff000   ( 372 kB)
[    0.000000]     vmalloc : 0xc87e0000 - 0xfffa0000   ( 887 MB)
[    0.000000]     lowmem  : 0xc0000000 - 0xc7fe0000   ( 127 MB)
[    0.000000]       .init : 0xc142b000 - 0xc1470000   ( 276 kB)
[    0.000000]       .data : 0xc134b52c - 0xc1429a80   ( 889 kB)
[    0.000000]       .text : 0xc1000000 - 0xc134b52c   (3373 kB)
[    0.000000] Checking if this processor honours the WP bit even in supervisor mode...Ok.
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] NR_IRQS:2304 nr_irqs:256 0
[    0.000000] Console: colour VGA+ 80x25
[    0.000000] console [tty0] enabled
[    0.000000] console [ttyS0] enabled
[    0.000000] tsc: Detected 2393.904 MHz processor
[    0.020000] Calibrating delay loop (skipped) preset value.. 4787.80 BogoMIPS (lpj=23939040)
[    0.020000] pid_max: default: 32768 minimum: 301
[    0.020000] ACPI: Core revision 20140926
[    0.022278] ACPI: All ACPI Tables successfully acquired
[    0.024821] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes)
[    0.027344] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes)
[    0.030389] mce: CPU supports 10 MCE banks
[    0.032190] Last level iTLB entries: 4KB 0, 2MB 0, 4MB 0
[    0.032190] Last level dTLB entries: 4KB 0, 2MB 0, 4MB 0, 1GB 0
[    0.036451] CPU: Intel QEMU Virtual CPU version 2.1.2 (fam: 06, model: 06, stepping: 03)
[    0.046042] Performance Events: Broken PMU hardware detected, using software events only.
[    0.050012] Failed to access perfctr msr (MSR c1 is 0)
[    0.052378] Enabling APIC mode:  Flat.  Using 1 I/O APICs
[    0.056810] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
[    0.060000] NET: Registered protocol family 16
[    0.060000] cpuidle: using governor ladder
[    0.060000] cpuidle: using governor menu
[    0.060000] ACPI: bus type PCI registered
[    0.060000] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
[    0.060171] PCI: PCI BIOS revision 2.10 entry at 0xfd456, last bus=1
[    0.062618] PCI: Using configuration type 1 for base access
[    0.066684] ACPI: Added _OSI(Module Device)
[    0.068535] ACPI: Added _OSI(Processor Device)
[    0.070006] ACPI: Added _OSI(3.0 _SCP Extensions)
[    0.071953] ACPI: Added _OSI(Processor Aggregator Device)
[    0.076647] ACPI: Interpreter enabled
[    0.078272] ACPI: (supports S0 S5)
[    0.080005] ACPI: Using IOAPIC for interrupt routing
[    0.082046] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
[    0.093670] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
[    0.096150] acpi PNP0A03:00: _OSC: OS supports [Segments MSI]
[    0.098433] acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
[    0.100184] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
[    0.104758] acpiphp: Slot [4] registered
[    0.106503] acpiphp: Slot [5] registered
[    0.108326] acpiphp: Slot [6] registered
[    0.110065] acpiphp: Slot [7] registered
[    0.111842] acpiphp: Slot [8] registered
[    0.113612] acpiphp: Slot [9] registered
[    0.115346] acpiphp: Slot [10] registered
[    0.117136] acpiphp: Slot [11] registered
[    0.118921] acpiphp: Slot [12] registered
[    0.120052] acpiphp: Slot [13] registered
[    0.121881] acpiphp: Slot [14] registered
[    0.123729] acpiphp: Slot [15] registered
[    0.125557] acpiphp: Slot [16] registered
[    0.127338] acpiphp: Slot [17] registered
[    0.130056] acpiphp: Slot [18] registered
[    0.131854] acpiphp: Slot [19] registered
[    0.133713] acpiphp: Slot [20] registered
[    0.135487] acpiphp: Slot [21] registered
[    0.137332] acpiphp: Slot [22] registered
[    0.139133] acpiphp: Slot [23] registered
[    0.140053] acpiphp: Slot [24] registered
[    0.141827] acpiphp: Slot [25] registered
[    0.143662] acpiphp: Slot [26] registered
[    0.145462] acpiphp: Slot [27] registered
[    0.147264] acpiphp: Slot [28] registered
[    0.150054] acpiphp: Slot [29] registered
[    0.151927] acpiphp: Slot [30] registered
[    0.153758] acpiphp: Slot [31] registered
[    0.155545] PCI host bridge to bus 0000:00
[    0.157334] pci_bus 0000:00: root bus resource [bus 00-ff]
[    0.160008] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7]
[    0.162463] pci_bus 0000:00: root bus resource [io  0x0d00-0xadff]
[    0.164908] pci_bus 0000:00: root bus resource [io  0xae0f-0xaeff]
[    0.167357] pci_bus 0000:00: root bus resource [io  0xaf20-0xafdf]
[    0.170006] pci_bus 0000:00: root bus resource [io  0xafe4-0xffff]
[    0.172464] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff]
[    0.175184] pci_bus 0000:00: root bus resource [mem 0x08000000-0xfebfffff]
[    0.184966] pci 0000:00:01.1: legacy IDE quirk: reg 0x10: [io  0x01f0-0x01f7]
[    0.187797] pci 0000:00:01.1: legacy IDE quirk: reg 0x14: [io  0x03f6]
[    0.190007] pci 0000:00:01.1: legacy IDE quirk: reg 0x18: [io  0x0170-0x0177]
[    0.192812] pci 0000:00:01.1: legacy IDE quirk: reg 0x1c: [io  0x0376]
[    0.196416] pci 0000:00:01.3: can't claim BAR 7 [io  0x0600-0x063f]: address conflict with ACPI PM1a_EVT_BLK [io  0x0600-0x0603]
[    0.200027] pci 0000:00:01.3: quirk: [io  0x0700-0x070f] claimed by PIIX4 SMB
[    0.237418] acpiphp: Slot [0] registered
[    0.239325] acpiphp: Slot [1] registered
[    0.240064] acpiphp: Slot [2] registered
[    0.241837] acpiphp: Slot [3] registered
[    0.243637] acpiphp: Slot [4-1] registered
[    0.245494] acpiphp: Slot [5-1] registered
[    0.247410] acpiphp: Slot [6-1] registered
[    0.250056] acpiphp: Slot [7-1] registered
[    0.251887] acpiphp: Slot [8-1] registered
[    0.253762] acpiphp: Slot [9-1] registered
[    0.255610] acpiphp: Slot [10-1] registered
[    0.257449] acpiphp: Slot [11-1] registered
[    0.259297] acpiphp: Slot [12-1] registered
[    0.260062] acpiphp: Slot [13-1] registered
[    0.261973] acpiphp: Slot [14-1] registered
[    0.263869] acpiphp: Slot [15-1] registered
[    0.265735] acpiphp: Slot [16-1] registered
[    0.267613] acpiphp: Slot [17-1] registered
[    0.270070] acpiphp: Slot [18-1] registered
[    0.271908] acpiphp: Slot [19-1] registered
[    0.273802] acpiphp: Slot [20-1] registered
[    0.275661] acpiphp: Slot [21-1] registered
[    0.277459] acpiphp: Slot [22-1] registered
[    0.280055] acpiphp: Slot [23-1] registered
[    0.281853] acpiphp: Slot [24-1] registered
[    0.283754] acpiphp: Slot [25-1] registered
[    0.290057] acpiphp: Slot [26-1] registered
[    0.293122] acpiphp: Slot [27-1] registered
[    0.294961] acpiphp: Slot [28-1] registered
[    0.296779] acpiphp: Slot [29-1] registered
[    0.298631] acpiphp: Slot [30-1] registered
[    0.300074] acpiphp: Slot [31-1] registered
[    0.312982] pci 0000:00:03.0: PCI bridge to [bus 01]
[    0.318519] ACPI: PCI Interrupt Link [LNKA] (IRQs 5 *10 11)
[    0.321694] ACPI: PCI Interrupt Link [LNKB] (IRQs 5 *10 11)
[    0.325023] ACPI: PCI Interrupt Link [LNKC] (IRQs 5 10 *11)
[    0.328227] ACPI: PCI Interrupt Link [LNKD] (IRQs 5 10 *11)
[    0.331585] ACPI: PCI Interrupt Link [LNKS] (IRQs *9)
[    0.334761] ACPI: Enabled 16 GPEs in block 00 to 0F
[    0.337651] SCSI subsystem initialized
[    0.340542] PCI: Using ACPI for IRQ routing
[    0.343050] HPET: 3 timers in total, 0 timers will be used for per-cpu timer
[    0.350911] Switched to clocksource kvm-clock
[    0.352842] pnp: PnP ACPI init
[    0.355431] pnp: PnP ACPI: found 6 devices
[    0.393437] pci 0000:00:01.3: BAR 7: [io  0x0600-0x063f] has bogus alignment
[    0.396088] pci 0000:00:03.0: PCI bridge to [bus 01]
[    0.398065] pci 0000:00:03.0:   bridge window [io  0xc000-0xcfff]
[    0.401743] pci 0000:00:03.0:   bridge window [mem 0xfe800000-0xfe9fffff]
[    0.405279] pci 0000:00:03.0:   bridge window [mem 0xfe000000-0xfe1fffff 64bit pref]
[    0.410429] NET: Registered protocol family 2
[    0.412621] TCP established hash table entries: 1024 (order: 0, 4096 bytes)
[    0.415261] TCP bind hash table entries: 1024 (order: 0, 4096 bytes)
[    0.417681] TCP: Hash tables configured (established 1024 bind 1024)
[    0.420138] TCP: reno registered
[    0.421654] UDP hash table entries: 256 (order: 0, 4096 bytes)
[    0.423980] UDP-Lite hash table entries: 256 (order: 0, 4096 bytes)
[    0.426517] NET: Registered protocol family 1
[    0.428350] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
[    0.430675] pci 0000:00:01.0: PIIX3: Enabling Passive Release
[    0.432957] pci 0000:00:01.0: Activating ISA DMA hang workarounds
[    0.435824] NatSemi SCx200 Driver
[    0.437560] futex hash table entries: 256 (order: -1, 3072 bytes)
[    0.443827] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.446172] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.450225] msgmni has been set to 243
[    0.452418] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 252)
[    0.455553] io scheduler noop registered
[    0.457222] io scheduler deadline registered (default)
[    0.459354] pci_hotplug: PCI Hot Plug PCI Core version: 0.5
[    0.461663] pciehp: PCI Express Hot Plug Controller Driver version: 0.4
[    0.464290] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input0
[    0.467329] ACPI: Power Button [PWRF]
[    0.517101] ACPI: PCI Interrupt Link [LNKD] enabled at IRQ 11
[    0.568150] ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 10

2017-06-17 23:30:38,211: launch     TRACE    OUTPUT: [    0.620266] ACPI: PCI Interrupt Link [LNKA] enabled at IRQ 10
[    0.623766] Serial: 8250/16550 driver, 16 ports, IRQ sharing enabled
[    0.649582] 00:05: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
[    0.653500] Non-volatile memory driver v1.3
[    0.659414] scsi host0: ata_piix
[    0.661074] scsi host1: ata_piix
[    0.662526] ata1: PATA max MWDMA2 cmd 0x1f0 ctl 0x3f6 bmdma 0xd020 irq 14
[    0.664969] ata2: PATA max MWDMA2 cmd 0x170 ctl 0x376 bmdma 0xd028 irq 15
[    0.667602] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
[    0.671775] serio: i8042 KBD port at 0x60,0x64 irq 1
[    0.673692] serio: i8042 AUX port at 0x60,0x64 irq 12
[    0.675725] rtc_cmos 00:00: RTC can wake from S4
[    0.677978] rtc_cmos 00:00: rtc core: registered rtc_cmos as rtc0
[    0.680605] rtc_cmos 00:00: alarms up to one day, 114 bytes nvram, hpet irqs
[    0.683187] TCP: cubic registered
[    0.684592] NET: Registered protocol family 17
[    0.686367] bridge: automatic filtering via arp/ip/ip6tables has been deprecated. Update your scripts to load br_netfilter if you need this.
[    0.690801] Bridge firewalling registered
[    0.692421] 8021q: 802.1Q VLAN Support v1.8
[    0.694322] Using IPI Shortcut mode
[    0.697018] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input1
[    0.701802] rtc_cmos 00:00: setting system clock to 2017-06-17 23:30:35 UTC (1497742235)
[    0.862169] ata2.00: ATAPI: QEMU DVD-ROM, 2.1.2, max UDMA/100
[    0.864684] ata1.00: ATA-7: QEMU HARDDISK, 2.1.2, max UDMA/100
[    0.866842] ata1.00: 107520 sectors, multi 16: LBA48
[    0.869435] ata2.00: configured for MWDMA2
[    0.871777] ata1.00: configured for MWDMA2
[    0.873599] scsi 0:0:0:0: Direct-Access     ATA      QEMU HARDDISK    2    PQ: 0 ANSI: 5
[    0.877431] sd 0:0:0:0: [sda] 107520 512-byte logical blocks: (55.0 MB/52.5 MiB)
[    0.880413] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.1. PQ: 0 ANSI: 5
[    0.883945] sd 0:0:0:0: [sda] Write Protect is off
[    0.885997] sd 0:0:0:0: [sda] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
[    0.890219]  sda: sda1 sda2
[    0.891803] sd 0:0:0:0: [sda] Attached SCSI disk
[    0.896812] EXT4-fs (sda2): mounted filesystem without journal. Opts: (null)
[    0.899351] VFS: Mounted root (ext4 filesystem) readonly on device 8:2.
[    0.901902] Freeing unused kernel memory: 276K (c142b000 - c1470000)
[    0.919017] init: Console is alive
[    1.440132] tsc: Refined TSC clocksource calibration: 2393.966 MHz
[    1.920947] init: - preinit -
[    1.939645] random: mktemp urandom read with 14 bits of entropy available
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level

2017-06-17 23:30:40,214: launch     TRACE    OUTPUT: [    3.958727] mount_root: mounting /dev/root
[    3.961004] EXT4-fs (sda2): warning: mounting unchecked fs, running e2fsck is recommended
[    3.964822] EXT4-fs (sda2): re-mounted. Opts: (null)
[    3.980105] EXT4-fs (sda1): mounted filesystem without journal. Opts: (null)
mv: can't rename '/mnt/sysupgrade.tgz': No such file or directory
[    3.989791] procd: - early -
[    4.517573] procd: - ubus -

2017-06-17 23:30:42,217: launch     TRACE    OUTPUT: [    5.530316] procd: - init -
Please press Enter to activate this console.
[    5.616860] NET: Registered protocol family 10
[    5.620304] ip6_tables: (C) 2000-2006 Netfilter Core Team
[    5.634569] ip_tables: (C) 2000-2006 Netfilter Core Team
[    5.638027] nf_conntrack version 0.5.0 (1949 buckets, 7796 max)
[    5.655094] xt_time: kernel timezone is -0000
[    5.658156] PPP generic driver version 2.4.2
[    5.660824] NET: Registered protocol family 24

2017-06-17 23:30:43,218: launch     DEBUG    VM started
2017-06-17 23:30:43,219: launch     INFO     applying bootstrap configuration
2017-06-17 23:30:43,219: vrnetlab   DEBUG    writing to serial console:
2017-06-17 23:30:43,219: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-17 23:30:43,241: vrnetlab   TRACE    read from serial console: : port 1(eth0) entered forwarding state
[    7.046657] br-lan: port 1(eth0) entered forwarding state
[    7.058461] 8021q: adding VLAN 0 to HW filter on device eth1




BusyBox v1.23.2 (2015-07-25 08:11:38 CEST) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 CHAOS CALMER (15.05, r46767)
 -----------------------------------------------------
  * 1 1/2 oz Gin            Shake with a glassful
  * 1/4 oz Triple Sec       of broken ice and pour
  * 3/4 oz Lime Juice       unstrained into a goblet.
  * 1 1/2 oz Orange Juice
  * 1 tsp. Grenadine Syrup
 -----------------------------------------------------
root@OpenWrt:/#
2017-06-17 23:30:43,241: vrnetlab   DEBUG    writing to serial console: ifconfig br-lan 10.0.0.15 netmask 255.255.255.0
2017-06-17 23:30:43,241: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-17 23:30:43,288: vrnetlab   TRACE    read from serial console:
root@OpenWrt:/#
2017-06-17 23:30:43,288: vrnetlab   DEBUG    writing to serial console: passwd
2017-06-17 23:30:43,288: vrnetlab   TRACE    waiting for 'New password:' on serial console
2017-06-17 23:30:43,338: vrnetlab   TRACE    read from serial console:  ifconfig br-lan 10.0.0.15 netmask 255.255.255.0
root@OpenWrt:/# passwd
Changing password for root
New password:
2017-06-17 23:30:43,338: vrnetlab   DEBUG    writing to serial console: VR-netlab9
2017-06-17 23:30:43,339: vrnetlab   TRACE    waiting for 'Retype password:' on serial console
2017-06-17 23:30:43,388: vrnetlab   TRACE    read from serial console:
Retype password:
2017-06-17 23:30:43,388: vrnetlab   DEBUG    writing to serial console: VR-netlab9
2017-06-17 23:30:43,389: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-17 23:30:43,440: vrnetlab   TRACE    read from serial console:
Password for root changed by root
root@OpenWrt:/#
2017-06-17 23:30:43,440: vrnetlab   DEBUG    writing to serial console: echo 'vrnetlab:x:501:501:vrnetlab:/home/vrnetlab:/bin/ash' >> /etc/passwd
2017-06-17 23:30:43,440: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-17 23:30:43,498: vrnetlab   TRACE    read from serial console:  echo 'vrnetlab:x:501:501:vrnetlab:/home/vrnetlab:/bin/ash' >> /e
tc/passwd
root@OpenWrt:/#
2017-06-17 23:30:43,499: vrnetlab   DEBUG    writing to serial console: passwd vrnetlab
2017-06-17 23:30:43,499: vrnetlab   TRACE    waiting for 'New password:' on serial console
2017-06-17 23:30:43,548: vrnetlab   TRACE    read from serial console:  passwd vrnetlab
passwd: no record of vrnetlab in /etc/shadow, using /etc/passwd
Changing password for vrnetlab
New password:
2017-06-17 23:30:43,548: vrnetlab   DEBUG    writing to serial console: VR-netlab9
2017-06-17 23:30:43,549: vrnetlab   TRACE    waiting for 'Retype password:' on serial console
2017-06-17 23:30:43,598: vrnetlab   TRACE    read from serial console:
Retype password:
2017-06-17 23:30:43,598: vrnetlab   DEBUG    writing to serial console: VR-netlab9
2017-06-17 23:30:43,599: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-17 23:30:43,650: vrnetlab   TRACE    read from serial console:
Password for vrnetlab changed by root
root@OpenWrt:/#
2017-06-17 23:30:43,650: vrnetlab   DEBUG    writing to serial console: sed -i '1d' /etc/group
2017-06-17 23:30:43,650: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-17 23:30:43,698: vrnetlab   TRACE    read from serial console:  sed -i '1d' /etc/group
root@OpenWrt:/#
2017-06-17 23:30:43,698: vrnetlab   DEBUG    writing to serial console: sed -i '1i root:x:0:vrnetlab' /etc/group
2017-06-17 23:30:43,698: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-17 23:30:43,748: vrnetlab   TRACE    read from serial console:  sed -i '1i root:x:0:vrnetlab' /etc/group
root@OpenWrt:/#
2017-06-17 23:30:43,748: vrnetlab   DEBUG    writing to serial console: mkdir -p /home/vrnetlab
2017-06-17 23:30:43,748: vrnetlab   TRACE    waiting for '#' on serial console
2017-06-17 23:30:43,798: vrnetlab   TRACE    read from serial console:  mkdir -p /home/vrnetlab
root@OpenWrt:/#
2017-06-17 23:30:43,798: vrnetlab   DEBUG    writing to serial console: chown vrnetlab /home/vrnetlab
2017-06-17 23:30:43,799: launch     INFO     completed bootstrap configuration
2017-06-17 23:30:43,799: launch     INFO     Startup complete in: 0:00:15.613734
```
