### PR TITLE
Install procps to make sysctl command available.

### DIFF
--- a/vr-bgp/Dockerfile
+++ b/vr-bgp/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update -qy \
  && apt-get install -y \
     git \
     golang \
+    procps \
     python \
     python-setuptools \
     python3-jinja2 \


### PR DESCRIPTION
Since 6ec2880f6ae8a0384eed7c93c6c76970c4fed885, `sysctl` command is used by vr-bgp. This PR installs the command as it is missing in debian:stable image.