### PR TITLE
Increase `VQFX_vcp` RAM to 2048 to avoid kernel panics.

### DIFF
--- a/vqfx/README.md
+++ b/vqfx/README.md
@@ -43,7 +43,7 @@ System requirements
 -------------------
 CPU: 2 cores
 
-RAM: 3072MB
+RAM: 4096MB
 
 Disk: 1.5GB
 

--- a/vqfx/docker/launch_vqfx.py
+++ b/vqfx/docker/launch_vqfx.py
@@ -40,7 +40,7 @@ class VQFX_vcp(vrnetlab.VM):
         for e in os.listdir("/"):
             if re.search("-re-.*.vmdk", e):
                 vrnetlab.run_command(["qemu-img", "create", "-b", "/" + e, "-f", "qcow", "/vcp.qcow2"])
-        super(VQFX_vcp, self).__init__(username, password, disk_image="/vcp.qcow2", ram=1024)
+        super(VQFX_vcp, self).__init__(username, password, disk_image="/vcp.qcow2", ram=2048)
         self.num_nics = 12
 
 


### PR DESCRIPTION
With only 1024MB RAM given to `VQFX_vcp`, we got frequent kernel panics early in the boot process. Increasing to 2048MB seems to work.

```
Calling dcf_ng_hw_init for platform hw vecs initialization
panic: pmap_mapdev: Couldn't alloc kernel virtual memory
KDB: stack backtrace:
kdb_backtrace(b0e5725b,b1f55c80,b0e425a0,b2421b80,0) at kdb_backtrace+0x29
panic(b0e425a0,d423c000,1f,b2421c50,b2421c04) at panic+0x283
pmap_mapdev(3ffe201f,d423b0b4,b2421bd4,b0526712,3ffe201f) at pmap_mapdev+0x71
AcpiOsMapMemory(3ffe201f,0,d423b0b4,b2421bc4,b2421bcc) at AcpiOsMapMemory+0x18
AcpiTbGetThisTable(b2421c44,b2421c04,b2421c50,0,b2421c04) at AcpiTbGetThisTable+0xe4
AcpiTbGetTableBody(b2421c44,b2421c04,b2421c50,d423a0b4,d423b0b4) at AcpiTbGetTableBody+0x47
AcpiTbGetTable(b2421c44,b2421c50,9,3ffe201f,0) at AcpiTbGetTable+0x3a
AcpiTbGetTableRsdt(b2421c98,b2421c98,b052b0b0,1,f68b0) at AcpiTbGetTableRsdt+0x2a
AcpiLoadTables(b0f04220,b0e503ec,0,0,b0e8ab60) at AcpiLoadTables+0xb0
acpi_Startup(b4d10d80,b0e5070a,0,b4d42030,b2421d00) at acpi_Startup+0x85
acpi_identify(b0e8ab60,b4d10d80,b0e94dd4,b4d10d80,0) at acpi_identify+0x57
bus_generic_probe(b4d10d80,b4d10d80,b2421d30,b065b219,b4d10d80) at bus_generic_probe+0x54
nexus_attach(b4d10d80,b4d4a054,b0e94de4,b4d10d80,b4d10d80) at nexus_attach+0x12
device_attach(b4d10d80,b4d10d80,b2421d68,b4d10d80,fffffff) at device_attach+0x5f
device_probe_and_attach(b4d10d80,b4cbcbb4,b2421d6c,b0bcb3f5,b0a5b014) at device_probe_and_attach+0xcf
root_bus_configure(b0a5b014,b2421d88,b05f8add,0,241eb00) at root_bus_configure+0x1b
configure(0,241eb00,241eb00,241e0
2017-08-16 10:34:56,829: launch_vqfx TRACE    OUTPUT VCP: 00,2426000) at configure+0xc
mi_startup() at mi_startup+0x90
begin() at begin+0x2c
Uptime: 1s
Automatic reboot in 15 seconds - press a key on the console to abort
```