### PR TITLE
Add support for vQFX to topomachine

### DIFF
--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -20,7 +20,7 @@ class VrTopo:
         for r, val in self.routers.items():
             if 'type' not in val:
                 raise ValueError("'type' is not defined for router %s" % r)
-            if val['type'] not in ('bgp', 'xrv', 'vmx', 'sros', 'csr'):
+            if val['type'] not in ('bgp', 'xrv', 'vmx', 'sros', 'csr', 'vqfx'):
                 raise ValueError("Unknown type %s for router %s" % (val['type'], r))
 
         # expand p2p links
@@ -105,6 +105,8 @@ class VrTopo:
             return "tap%d" % (interface-1)
         elif r['type'] == 'csr':
             return "GigabitEthernet%d" % (interface+1)
+        elif r['type'] == 'vqfx':
+            return "xe-0/0/%d" % (interface-1)
 
         return None
 


### PR DESCRIPTION
The vQFX, even though it is technically a switch, is still configured via the `routers` dict in hltopo.json. It made sense to me, since topomachine isn't really aware of the function anyway.