### PR TITLE
topomachine also generates a `links_by_nodes` dict in lltopo.

### DIFF
--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -51,7 +51,9 @@ class VrTopo:
                         'their_interface': link[b]['interface'],
                         'our_numeric': link[a]['numeric'],
                         'their_numeric': link[b]['numeric']}
-                self.links_by_nodes[link[a]['router']].update({link[b]['router']: spec})
+                if link[b]['router'] not in self.links_by_nodes[link[a]['router']]:
+                    self.links_by_nodes[link[a]['router']][link[b]['router']] = []
+                self.links_by_nodes[link[a]['router']][link[b]['router']].append(spec)
 
         for router in sorted(self.routers):
             val = self.routers[router]

--- a/topology-machine/topomachine
+++ b/topology-machine/topomachine
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+import collections
 
 import jinja2
 
@@ -40,6 +41,17 @@ class VrTopo:
                 links.extend(fmlinks)
 
         self.links = self.assign_interfaces(links)
+
+        self.links_by_nodes = collections.OrderedDict()
+        for l in self.links:
+            for (link, a, b) in ((l, 'left', 'right'), (l, 'right', 'left')):
+                if link[a]['router'] not in self.links_by_nodes:
+                    self.links_by_nodes[link[a]['router']] = collections.OrderedDict()
+                spec = {'our_interface': link[a]['interface'],
+                        'their_interface': link[b]['interface'],
+                        'our_numeric': link[a]['numeric'],
+                        'their_numeric': link[b]['numeric']}
+                self.links_by_nodes[link[a]['router']].update({link[b]['router']: spec})
 
         for router in sorted(self.routers):
             val = self.routers[router]
@@ -138,7 +150,8 @@ class VrTopo:
         """
         output = {
                 'routers': self.routers,
-                'links': self.links
+                'links': self.links,
+                'links_by_nodes': self.links_by_nodes
             }
 
         if output_format == 'json':


### PR DESCRIPTION
The original generated `links` dict makes it difficult to find peers and their interfaces for a given router.

An example for a p2p link between bgp1(tap0) - r1(xe-0/0/1):
```
    "links_by_nodes": {
        "bgp1": {
            "r1": {
                "our_interface": "tap0",
                "our_numeric": 1,
                "their_interface": "xe-0/0/1",
                "their_numeric": 2
            }
        },
        "r1": {
            "bgp1": {
                "our_interface": "xe-0/0/1",
                "our_numeric": 2,
                "their_interface": "tap0",
                "their_numeric": 1
            }
        }
    }
```