### PR TITLE
update veos makefile to match EFT release names

### DIFF
--- a/veos/Makefile
+++ b/veos/Makefile
@@ -7,7 +7,8 @@ IMAGE_GLOB=*.vmdk
 # vEOS-lab-4.16.6M.vmdk
 # vEOS-lab-4.17.1.1F.vmdk
 # vEOS-lab-4.17.1F.vmdk
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.*-\([0-9]\.\([0-9]\+\.\)\{1,2\}[0-9][A-Z]\)\.vmdk$$/\1/')
+# vEOS-lab-4.20.0-EFT2.vmdk
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.*-\([0-9]\.\([0-9]\+\.\)\{1,2\}[0-9]\([A-Z]\|\-EFT[0-9]\)\)\.vmdk$$/\1/')
 
 -include ../makefile-sanity.include
 -include ../makefile.include


### PR DESCRIPTION
Arista uses a slightly different naming convention for pre-release images. Update the regexp in the veos `Makefile` to support these version names.