### PR TITLE
Move IP addressing setup from vr-bgp to vr-xcon

### DIFF
--- a/vr-bgp/vr-bgp.py
+++ b/vr-bgp/vr-bgp.py
@@ -21,10 +21,15 @@ signal.signal(signal.SIGTERM, handle_SIGTERM)
 signal.signal(signal.SIGCHLD, handle_SIGCHLD)
 
 
-def config_ip(config, input_net, man_address, man_next_hop):
-    """ Configure IP address on the specified interface and set default route
+def calculate_ip_addressing(input_net, man_address, man_next_hop):
+    """ Calculate IP addressing (address, neighbor, default route) on the specified interface
 
-        This function is AFI agnostic, just feed it ipaddress objects
+        This function is AFI agnostic, just feed it ipaddress objects.
+
+        :param input_net: the IPv4/IPv6 network to use
+        :param man_address: optional override for the host address
+        :param man_next_hop: optional override for default route
+        :return: tuple of (local_address, neighbor, next_hop, prefixlen)
     """
     net = ipaddress.ip_network(input_net)
     if net.prefixlen == (net.max_prefixlen-1):
@@ -56,16 +61,7 @@ def config_ip(config, input_net, man_address, man_next_hop):
 
     print("network: {}  using address: {}".format(net, address))
 
-    config['IPV{}_LOCAL_ADDRESS'.format(net.version)] = address
-    config['IPV{}_NEIGHBOR'.format(net.version)] = neighbor
-
-    subprocess.check_call(["ip", "-{}".format(net.version), "address", "add", str(address) + "/" + str(net.prefixlen), "dev", config['INTERFACE']])
-    try:
-        subprocess.check_call(["ip", "-{}".format(net.version), "route", "del", "default"])
-    except:
-        pass
-    subprocess.check_call(["ip", "-{}".format(net.version), "route", "add", "default", "dev", config['INTERFACE'], "via", str(next_hop)])
-
+    return str(address), str(neighbor), str(next_hop), net.prefixlen
 
 
 if __name__ == '__main__':
@@ -97,17 +93,6 @@ if __name__ == '__main__':
     if args.debug:
         logger.setLevel(logging.DEBUG)
 
-    if not os.path.exists("/dev/net/tun"):
-        print("No TUN device - make sure you run the container with --privileged", file=sys.stderr)
-        sys.exit(1)
-
-    # start tcp2tap to listen on incoming TCP. vr-xcon will then connect us to
-    # the virtual router
-    t2t = subprocess.Popen(["/xcon.py", "--tap-listen", "1"])
-    # wait for tcp2tap to bring up the tap0 interface
-    time.sleep(1)
-    subprocess.check_call(["ip", "link", "set", "tap0", "up"])
-
     config = {
         'IPV4_NEIGHBOR': None,
         'IPV6_NEIGHBOR': None,
@@ -120,33 +105,22 @@ if __name__ == '__main__':
         'MD5': args.md5,
         'INTERFACE': 'tap0',
         'INTERFACE_VLAN': None,
-        'INTERFACE_SYSCTL': 'tap0',
         'ALLOW_MIXED_AFI_TRANSPORT': args.allow_mixed_afi_transport
     }
 
     if args.vlan:
         vlan_intf = "tap0.{}".format(args.vlan)
-        sysctl_vlan_intf = "tap0/{}".format(args.vlan)
-        subprocess.check_call(["ip", "link", "add", "link", "tap0", "name",
-                               vlan_intf, "type", "vlan", "id", str(args.vlan)])
-        subprocess.check_call(["ip", "link", "set", vlan_intf, "up"])
         config['INTERFACE'] = vlan_intf
         config['INTERFACE_PHY'] = 'tap0'
         config['INTERFACE_VLAN'] = args.vlan
-        config['INTERFACE_SYSCTL'] = sysctl_vlan_intf
 
-    # stupid hack for docker engine disabling IPv6. It's somewhere around
-    # version 17.04 that docker engine started disabling ipv6 on the sysctl
-    # net.ipv6.conf.all and net.ipv6.conf.default while eth0 and lo still has
-    # it, if docker engine is started with --ipv6. However, with the default at
-    # disable we have to specifically enable it for interfaces created after the
-    # container started...
-    subprocess.check_call(["sysctl", "net.ipv6.conf.{}.disable_ipv6=0".format(config['INTERFACE_SYSCTL'])])
+
 
     if args.ipv4_prefix:
-        config_ip(config, args.ipv4_prefix,
-            args.ipv4_local_address,
-            args.ipv4_next_hop)
+        config['IPV4_LOCAL_ADDRESS'], config['IPV4_NEIGHBOR'], config['IPV4_NEXT_HOP'], config['IPV4_PREFIXLEN'] = \
+            calculate_ip_addressing(args.ipv4_prefix,
+                                    args.ipv4_local_address,
+                                    args.ipv4_next_hop)
 
         if args.ipv4_neighbor:
             config['IPV4_NEIGHBOR'] = args.ipv4_neighbor
@@ -166,9 +140,10 @@ if __name__ == '__main__':
 
 
     if args.ipv6_prefix:
-        config_ip(config, args.ipv6_prefix,
-            args.ipv6_local_address,
-            args.ipv6_next_hop)
+        config['IPV6_LOCAL_ADDRESS'], config['IPV6_NEIGHBOR'], config['IPV6_NEXT_HOP'], config['IPV6_PREFIXLEN'] = \
+            calculate_ip_addressing(args.ipv6_prefix,
+                                    args.ipv6_local_address,
+                                    args.ipv6_next_hop)
 
         if args.ipv6_neighbor:
             config['IPV6_NEIGHBOR'] = args.ipv6_neighbor
@@ -186,6 +161,28 @@ if __name__ == '__main__':
             print("--ipv6-local-address requires --ipv6-prefix to be specified", file=sys.stderr)
             sys.exit(1)
 
+    # start vr-xcon & configure ip addressing
+    if not os.path.exists("/dev/net/tun"):
+        print("No TUN device - make sure you run the container with --privileged", file=sys.stderr)
+        sys.exit(1)
+
+    # start tcp2tap to listen on incoming TCP. vr-xcon will then connect us to
+    # the virtual router
+    xcon_params = ["/xcon.py", "--tap-listen", "1"]
+    # if there is an address configured for v4/v6, pass it to xcon
+    for af in (4, 6):
+        if config["IPV{}_LOCAL_ADDRESS".format(af)]:
+            address = "{}/{}".format(config["IPV{}_LOCAL_ADDRESS".format(af)], config["IPV{}_PREFIXLEN".format(af)])
+            xcon_params.extend(("--ipv{}-address".format(af), address))
+            xcon_params.extend(("--ipv{}-route".format(af), config["IPV{}_NEXT_HOP".format(af)]))
+    if args.vlan:
+        xcon_params.extend(("--vlan", str(args.vlan)))
+    t2t = subprocess.Popen(xcon_params)
+
+    # TODO(mzagozen): is this needed?
+    # wait for tcp2tap to bring up the tap0 interface
+    time.sleep(1)
+    subprocess.check_call(["ip", "link", "set", "tap0", "up"])
 
     # generate exabgp config using Jinja2 template
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(['/']))

--- a/vr-bgp/vr-bgp.py
+++ b/vr-bgp/vr-bgp.py
@@ -179,11 +179,6 @@ if __name__ == '__main__':
         xcon_params.extend(("--vlan", str(args.vlan)))
     t2t = subprocess.Popen(xcon_params)
 
-    # TODO(mzagozen): is this needed?
-    # wait for tcp2tap to bring up the tap0 interface
-    time.sleep(1)
-    subprocess.check_call(["ip", "link", "set", "tap0", "up"])
-
     # generate exabgp config using Jinja2 template
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(['/']))
     template = env.get_template("/exabgp.conf.tpl")

--- a/vr-xcon/xcon.py
+++ b/vr-xcon/xcon.py
@@ -218,17 +218,6 @@ class TapConfigurator(object):
     def __init__(self, logger):
         self.logger = logger
 
-    def _wait_for_interface(self, interface):
-        self.logger.debug(interface)
-        while True:
-            try:
-                subprocess.check_call((["ip", "link", "show", interface]))
-                break
-            except subprocess.CalledProcessError:
-                self.logger.debug("Waiting for interface {} to appear".format(interface))
-                time.sleep(1)
-
-
     def _configure_interface_address(self, interface, address, default_route=None):
         net = ipaddress.ip_interface(address)
         if default_route:
@@ -254,9 +243,8 @@ class TapConfigurator(object):
     def configure_interface(self, interface='tap0', vlan=None,
                             ipv4_address=None, ipv4_route=None,
                             ipv6_address=None, ipv6_route=None):
-        # create the interface, wait until it exists
+        # enable the interface
         subprocess.check_call(["ip", "link", "set", interface, "up"])
-        self._wait_for_interface(interface)
 
         interface_sysctl = interface
         if vlan:
@@ -266,7 +254,6 @@ class TapConfigurator(object):
             subprocess.check_call(["ip", "link", "add", "link", physical_interface, "name",
                                    interface, "type", "vlan", "id", str(vlan)])
             subprocess.check_call(["ip", "link", "set", interface, "up"])
-            self._wait_for_interface(interface)
 
         if ipv4_address:
             self._configure_interface_address(interface, ipv4_address, ipv4_route)

--- a/vr-xcon/xcon.py
+++ b/vr-xcon/xcon.py
@@ -162,7 +162,7 @@ class TcpBridge:
         self.socket2remote[left] = right
         self.socket2remote[right] = left
 
-        
+
 
     def work(self):
         while True:
@@ -211,15 +211,18 @@ class TcpBridge:
 class NoVR(Exception):
     """ No virtual router
     """
-            
+
 
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='')
     parser.add_argument('--debug', action="store_true", default=False, help='enable debug')
-    parser.add_argument('--p2p', nargs='+', help='point-to-point link between virtual routers')
-    parser.add_argument('--tap-listen', help='tap to virtual router. Will listen on specified port for incoming connection; 1 for TCP/10001')
-    parser.add_argument('--tap-if', default="tap0", help='name of tap interface (use with other --tap-* arguments)')
+    p2p = parser.add_argument_group('p2p')
+    p2p.add_argument('--p2p', nargs='+', help='point-to-point link between virtual routers')
+    tap = parser.add_argument_group('tap')
+    tap.add_argument('--tap-listen', help='tap to virtual router. Will listen on specified port for incoming connection; 1 for TCP/10001')
+    tap.add_argument('--tap-if', default="tap0", help='name of tap interface (use with other --tap-* arguments)')
+    parser.add_argument('--trace', action="store_true", help="dummy, we don't support tracing but taking the option makes vrnetlab containers uniform")
     args = parser.parse_args()
 
     # sanity

--- a/vr-xcon/xcon.py
+++ b/vr-xcon/xcon.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
 import fcntl
+import ipaddress
 import logging
 import os
 import select
 import signal
 import socket
 import struct
+import subprocess
 import sys
 
 
@@ -212,6 +214,73 @@ class NoVR(Exception):
     """ No virtual router
     """
 
+class TapConfigurator(object):
+    def __init__(self, logger):
+        self.logger = logger
+
+    def _wait_for_interface(self, interface):
+        self.logger.debug(interface)
+        while True:
+            try:
+                subprocess.check_call((["ip", "link", "show", interface]))
+                break
+            except subprocess.CalledProcessError:
+                self.logger.debug("Waiting for interface {} to appear".format(interface))
+                time.sleep(1)
+
+
+    def _configure_interface_address(self, interface, address, default_route=None):
+        net = ipaddress.ip_interface(address)
+        if default_route:
+            try:
+                next_hop = ipaddress.ip_address(default_route)
+            except ValueError:
+                self.logger.error("next-hop address {} could not be parsed".format(default_route))
+                sys.exit(1)
+
+        if default_route and next_hop not in net.network:
+            self.logger.error("next-hop address {} not in network {}".format(next_hop, net))
+            sys.exit(1)
+
+        subprocess.check_call(["ip", "-{}".format(net.version), "address", "add", str(net.ip) + "/" + str(net.network.prefixlen), "dev", interface])
+        if next_hop:
+            try:
+                subprocess.check_call(["ip", "-{}".format(net.version), "route", "del", "default"])
+            except:
+                pass
+            subprocess.check_call(["ip", "-{}".format(net.version), "route", "add", "default", "dev", interface, "via", str(next_hop)])
+
+
+    def configure_interface(self, interface='tap0', vlan=None,
+                            ipv4_address=None, ipv4_route=None,
+                            ipv6_address=None, ipv6_route=None):
+        # create the interface, wait until it exists
+        subprocess.check_call(["ip", "link", "set", interface, "up"])
+        self._wait_for_interface(interface)
+
+        interface_sysctl = interface
+        if vlan:
+            physical_interface = interface
+            interface_sysctl = '{}/{}'.format(interface, vlan)
+            interface = '{}.{}'.format(interface, vlan)
+            subprocess.check_call(["ip", "link", "add", "link", physical_interface, "name",
+                                   interface, "type", "vlan", "id", str(vlan)])
+            subprocess.check_call(["ip", "link", "set", interface, "up"])
+            self._wait_for_interface(interface)
+
+        if ipv4_address:
+            self._configure_interface_address(interface, ipv4_address, ipv4_route)
+
+        if ipv6_address:
+            # stupid hack for docker engine disabling IPv6. It's somewhere around
+            # version 17.04 that docker engine started disabling ipv6 on the sysctl
+            # net.ipv6.conf.all and net.ipv6.conf.default while eth0 and lo still has
+            # it, if docker engine is started with --ipv6. However, with the default at
+            # disable we have to specifically enable it for interfaces created after the
+            # container started...
+            subprocess.check_call(["sysctl", "net.ipv6.conf.{}.disable_ipv6=0".format(interface_sysctl)])
+            self._configure_interface_address(interface, ipv6_address, ipv6_route)
+
 
 if __name__ == '__main__':
     import argparse
@@ -222,6 +291,11 @@ if __name__ == '__main__':
     tap = parser.add_argument_group('tap')
     tap.add_argument('--tap-listen', help='tap to virtual router. Will listen on specified port for incoming connection; 1 for TCP/10001')
     tap.add_argument('--tap-if', default="tap0", help='name of tap interface (use with other --tap-* arguments)')
+    tap.add_argument('--ipv4-address', help='IPv4 address to use on the tap interface')
+    tap.add_argument('--ipv4-route', help='default IPv4 route to use on the tap interface')
+    tap.add_argument('--ipv6-address', help='IPv6 address to use on the tap interface')
+    tap.add_argument('--ipv6-route', help='default IPv6 route to use on the tap interface')
+    tap.add_argument('--vlan', type=int, help='VLAN ID to use on the tap interface')
     parser.add_argument('--trace', action="store_true", help="dummy, we don't support tracing but taking the option makes vrnetlab containers uniform")
     args = parser.parse_args()
 
@@ -248,5 +322,12 @@ if __name__ == '__main__':
         tt.work()
 
     if args.tap_listen:
+        # init Tcp2Tap to create interface
         t2t = Tcp2Tap(args.tap_if, 10000 + int(args.tap_listen))
+
+        # now (optionally) configure addressing
+        tc = TapConfigurator(logger)
+        tc.configure_interface(interface=args.tap_if, vlan=args.vlan,
+                               ipv4_address=args.ipv4_address, ipv4_route=args.ipv4_route,
+                               ipv6_address=args.ipv6_address, ipv6_route=args.ipv6_route)
         t2t.work()


### PR DESCRIPTION
This PR adds a new feature to `xcon.py` - the ability to set up IP addressing + VLAN ID on the overlay _tap_ interface. Of course, this only applies to the _Tcp2Tap_ mode. I updated the documentation with an usage example.

This new feature is now also used from vr-bgp to configure the overlay address.