### PR TITLE
Improve docker images build for private registries.

### DIFF
--- a/vr-bgp/Dockerfile
+++ b/vr-bgp/Dockerfile
@@ -1,4 +1,5 @@
-FROM vrnetlab/vr-xcon
+ARG REGISTRY=vrnetlab/
+FROM ${REGISTRY}vr-xcon
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/vr-bgp/Makefile
+++ b/vr-bgp/Makefile
@@ -1,7 +1,7 @@
 -include ../makefile-sanity.include
 
 all:
-	docker build --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy) -t $(REGISTRY)vr-bgp .
+	docker build --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy) --build-arg REGISTRY=$(REGISTRY) -t $(REGISTRY)vr-bgp .
 
 docker-push:
 	docker push $(REGISTRY)vr-bgp


### PR DESCRIPTION
The vr-bgp image uses vr-xcon as a _FROM_. However, it had a hardoded
`vrnetlab/vr-xcon` image name, implying the usage of the public Docker
Hub image.

If you wanted to use a private registry by setting the env var
`$DOCKER_REGISTRY`, the built images were tagged correctly, but vr-bgp
actually still used the Docker Hub image.

By using a build _ARG_ in _FROM_ for vr-bgp, this is avoided.