### PR TITLE
Add support for exabgp "ttl-security" setting to vr-bgp

### DIFF
--- a/makefile-sanity.include
+++ b/makefile-sanity.include
@@ -4,5 +4,5 @@ $(error Bad docker registry URL. Should follow format registry.example.com:1234 
 endif
     REGISTRY=$(DOCKER_REGISTRY)/
 else
-    REGISTRY=
+    REGISTRY=vrnetlab/
 endif

--- a/vr-bgp/exabgp.conf.tpl
+++ b/vr-bgp/exabgp.conf.tpl
@@ -31,6 +31,9 @@ group test {
         {%- if config.LISTEN %}
         listen 179;
         {%- endif %}
+        {%- if config.TTLSECURITY %}
+        ttl-security;
+        {%- endif %}
     }
 {%- endif %}
 {%- if config.IPV6_NEIGHBOR %}
@@ -47,6 +50,9 @@ group test {
         {%- endif %}
         {%- if config.LISTEN %}
         listen 179;
+        {%- endif %}
+        {%- if config.TTLSECURITY %}
+        ttl-security;
         {%- endif %}
     }
 {%- endif %}

--- a/vr-bgp/vr-bgp.py
+++ b/vr-bgp/vr-bgp.py
@@ -84,6 +84,7 @@ if __name__ == '__main__':
     parser.add_argument('--md5', help='MD5')
     parser.add_argument('--trace', action='store_true', help='enable trace level logging')
     parser.add_argument('--vlan', type=int, help='VLAN ID to use')
+    parser.add_argument('--ttl-security', action="store_true", help='Enable TTL security')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
@@ -105,7 +106,8 @@ if __name__ == '__main__':
         'MD5': args.md5,
         'INTERFACE': 'tap0',
         'INTERFACE_VLAN': None,
-        'ALLOW_MIXED_AFI_TRANSPORT': args.allow_mixed_afi_transport
+        'ALLOW_MIXED_AFI_TRANSPORT': args.allow_mixed_afi_transport,
+        'TTLSECURITY': args.ttl_security
     }
 
     if args.vlan:


### PR DESCRIPTION
Hi,

I've added the ttl-security ExaBGP option to vr-bgp.

Also, the build was failing if the REGISTRY env variable wasn't set, so I've put the default to "vrnetlab/"

Both done per @mzagozen 's suggestions.