### PR TITLE
added support for native docker networking

### DIFF
--- a/csr/docker/launch.py
+++ b/csr/docker/launch.py
@@ -33,7 +33,7 @@ logging.Logger.trace = trace
 
 
 class CSR_vm(vrnetlab.VM):
-    def __init__(self, username, password, install_mode=False):
+    def __init__(self, username, password, install_mode=False, meshnet=False):
         for e in os.listdir("/"):
             if re.search(".qcow2$", e):
                 disk_image = "/" + e
@@ -49,6 +49,7 @@ class CSR_vm(vrnetlab.VM):
 
         self.install_mode = install_mode
         self.num_nics = 9
+        self.meshnet = meshnet
 
         if self.install_mode:
             logger.trace("install mode")
@@ -156,9 +157,9 @@ class CSR_vm(vrnetlab.VM):
 
 
 class CSR(vrnetlab.VR):
-    def __init__(self, username, password):
+    def __init__(self, username, password, meshnet=False):
         super(CSR, self).__init__(username, password)
-        self.vms = [ CSR_vm(username, password) ]
+        self.vms = [ CSR_vm(username, password, meshnet=meshnet) ]
 
 
 class CSR_installer(CSR):
@@ -188,6 +189,7 @@ if __name__ == '__main__':
     parser.add_argument('--username', default='vrnetlab', help='Username')
     parser.add_argument('--password', default='VR-netlab9', help='Password')
     parser.add_argument('--install', action='store_true', help='Install CSR')
+    parser.add_argument('--meshnet', action='store_true', help='Native docker networking')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
@@ -202,5 +204,5 @@ if __name__ == '__main__':
         vr = CSR_installer(args.username, args.password)
         vr.install()
     else:
-        vr = CSR(args.username, args.password)
+        vr = CSR(args.username, args.password, meshnet=args.meshnet)
         vr.start()

--- a/xrv/docker/launch.py
+++ b/xrv/docker/launch.py
@@ -33,7 +33,7 @@ logging.Logger.trace = trace
 
 
 class XRV_vm(vrnetlab.VM):
-    def __init__(self, username, password):
+    def __init__(self, username, password, meshnet=False):
         for e in os.listdir("/"):
             if re.search(".vmdk", e):
                 disk_image = "/" + e
@@ -44,6 +44,7 @@ class XRV_vm(vrnetlab.VM):
             ]
 
         self.xr_ready = False
+        self.meshnet = meshnet
 
 
     def bootstrap_spin(self):
@@ -164,9 +165,9 @@ class XRV_vm(vrnetlab.VM):
 
 
 class XRV(vrnetlab.VR):
-    def __init__(self, username, password):
+    def __init__(self, username, password, meshnet):
         super(XRV, self).__init__(username, password)
-        self.vms = [ XRV_vm(username, password) ]
+        self.vms = [ XRV_vm(username, password, meshnet) ]
 
 
 
@@ -176,6 +177,7 @@ if __name__ == '__main__':
     parser.add_argument('--trace', action='store_true', help='enable trace level logging')
     parser.add_argument('--username', default='vrnetlab', help='Username')
     parser.add_argument('--password', default='VR-netlab9', help='Password')
+    parser.add_argument('--meshnet', action='store_true', help='Native docker networking mode')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
@@ -186,5 +188,5 @@ if __name__ == '__main__':
     if args.trace:
         logger.setLevel(1)
 
-    vr = XRV(args.username, args.password)
+    vr = XRV(args.username, args.password, meshnet=args.meshnet)
     vr.start()


### PR DESCRIPTION
Hey Kristian,
I've got your images working with native docker networking (main goal being to run it inside k8s). As I've said it only took a few minor changes to `vrnetlab.py` + small changes to individual `launch.py` to pass the flag at runtime. I've tried attaching VMs via macvtap but it doesn't seem to work from inside the container so I've resorted to plain-old `eth-bridge-tap` (which means that spanning-tree won't work).
Have a look, tell me what you think. I'm getting back to work now so I didn't have time to run large-scale tests yet. So far I've tested it with a simple script connecting CSR/XRV and  vMX back-to-back (example for vmx):

```
docker create --name vmx --privileged vrnetlab/vr-vmx:17.2R1.13 --meshnet
docker network connect net1 vmx
docker network connect net2 vmx
docker network connect net3 vmx
docker start vmx
```