### PR TITLE
sros changed chassis type to SR-1s as SR-c12 has been discontinued in…

### DIFF
--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -149,7 +149,7 @@ class SROS_integrated(SROS_vm):
         super(SROS_integrated, self).__init__(username, password)
 
         self.num_nics = 5
-        self.smbios = ["type=1,product=TIMOS:address=10.0.0.15/24@active license-file=tftp://10.0.0.2/license.txt slot=A chassis=SR-c12 card=cfm-xp-b mda/1=m20-1gb-xp-sfp"]
+        self.smbios = ["type=1,product=TIMOS:address=10.0.0.15/24@active license-file=tftp://10.0.0.2/license.txt slot=A chassis=SR-1s card=xcm-1s mda/1=s36-400gb-qsfpdd"]
 
 
 


### PR DESCRIPTION
… 19.5.R1

I changed the chassis type to a 7750 SR-1s with a s36-400gb-qsfpdd:he4800g mda, as support for the 7750 SR-c12 has been removed from release 19.5.R1.

This will break backwards compatibility for releases that do not support the SR-1s, but the c12/c4 do not work in release 19.  The only other integrated chassis that is supported is a SR-1, which is also a FP4 based chassis, so it requires a relatively new release.