### PR TITLE
Fix logic error

### DIFF
--- a/makefile.include
+++ b/makefile.include
@@ -37,7 +37,7 @@ docker-push:
 
 docker-push-image:
 	@if [ -z "$$IMAGE" ]; then echo "ERROR: No IMAGE specified"; exit 1; fi
-	@if [ "$(IMAGE)" = "$(VERSION)" ]; then echo "ERROR: Incorrect version string"; exit 1; fi
+	@if [ "$(IMAGE)" != "$(VERSION)" ]; then echo "ERROR: Incorrect version string"; exit 1; fi
 	docker push $(REGISTRY)vr-$(VR_NAME):$(VERSION)
 
 usage:


### PR DESCRIPTION
Prior to this change, 'make docker-image' was failing for nxos builds because the makefile variable $IMAGE and $VERSION were the same causing the script to fail, but the intent of the conditional that compares these two values appears to have been put in place to fail if they were NOT the same. This change adjusts the conditional to correct this logic error.