### PR TITLE
fix openwrt's download.py: download url and local filename

### DIFF
--- a/openwrt/download.py
+++ b/openwrt/download.py
@@ -20,10 +20,10 @@ def get_rel(url, version):
         if not re.search('combined-ext4.img.gz', filename):
             #print("ignoring {}".format(filename))
             continue
-        if re.search('[^0-9][0-9]{2}\.[0-9]{2}[^0-9]', filename):
-            local_filename = filename
+        if re.search('^openwrt-x86-', filename):
+            local_filename = re.sub('^openwrt-x86-', 'openwrt-{}-x86-'.format(version), filename)
         else:
-            local_filename = re.sub('^openwrt-', 'openwrt-{}-'.format(version), filename)
+            local_filename = "openwrt-{}-x86-kvm_guest-{}".format(version, filename)
         file_url = "{}{}".format(url, filename)
         print("Downloading {} -> {}".format(file_url, local_filename))
         r = requests.get(file_url, stream=True)
@@ -39,7 +39,11 @@ def main():
     soup = BeautifulSoup(c, "lxml")
     links = soup.find_all("a")
     for l in links:
-        rel_url = "{}{}x86/kvm_guest/".format(base_url, l.attrs['href'])
+        m = re.search('^http(s|):\/\/', l.attrs['href'])
+        if not m:
+            rel_url = "{}{}x86/kvm_guest/".format(base_url, l.attrs['href'])
+        else:
+            rel_url = "{}x86/kvm_guest/".format(l.attrs['href'])
         m = re.search('[^0-9]([0-9]{2}\.[0-9]{2})[^0-9]', l.attrs['href'])
         if not m:
             continue


### PR DESCRIPTION
Hi, 

I couldn't download/generate docker images for OpenWRT.

It seems that URL href for some version has changed(some relative, some absolute).
This fix downloads targets from proper path.

Also, this includes fix for minor bug in renaming local filename, adds version string to them.
Makefile expects every image filename includes version string, while they are typically just "combined-ext4.img".


before
```
% make build 
python3 download.py
OpenWrt 18.06.4 releases/18.06.4/targets/ https://downloads.openwrt.org/releases/18.06.4/targets/x86/kvm_guest/
LEDE 17.01.6 releases/17.01.6/targets/ https://downloads.openwrt.org/releases/17.01.6/targets/x86/kvm_guest/
OpenWrt 18.06.3 http://archive.openwrt.org/releases/18.06.3/targets/ https://downloads.openwrt.org/http://archive.openwrt.org/releases/18.06.3/targets/x86/kvm_guest/
OpenWrt 18.06.2 http://archive.openwrt.org/releases/18.06.2/targets/ https://downloads.openwrt.org/http://archive.openwrt.org/releases/18.06.2/targets/x86/kvm_guest/
OpenWrt 18.06.1 http://archive.openwrt.org/releases/18.06.1/targets/ https://downloads.openwrt.org/http://archive.openwrt.org/releases/18.06.1/targets/x86/kvm_guest/
OpenWrt 18.06.0 http://archive.openwrt.org/releases/18.06.0/targets/ https://downloads.openwrt.org/http://archive.openwrt.org/releases/18.06.0/targets/x86/kvm_guest/
LEDE 17.01.5 http://archive.openwrt.org/releases/17.01.5/targets/ https://downloads.openwrt.org/http://archive.openwrt.org/releases/17.01.5/targets/x86/kvm_guest/
LEDE 17.01.4 http://archive.openwrt.org/releases/17.01.4/targets/ https://downloads.openwrt.org/http://archive.openwrt.org/releases/17.01.4/targets/x86/kvm_guest/
LEDE 17.01.3 http://archive.openwrt.org/releases/17.01.3/targets/ https://downloads.openwrt.org/http://archive.openwrt.org/releases/17.01.3/targets/x86/kvm_guest/
LEDE 17.01.2 http://archive.openwrt.org/releases/17.01.2/targets/ https://downloads.openwrt.org/http://archive.openwrt.org/releases/17.01.2/targets/x86/kvm_guest/
LEDE 17.01.1 http://archive.openwrt.org/releases/17.01.1/targets/ https://downloads.openwrt.org/http://archive.openwrt.org/releases/17.01.1/targets/x86/kvm_guest/
LEDE 17.01.0 http://archive.openwrt.org/releases/17.01.0/targets/ https://downloads.openwrt.org/http://archive.openwrt.org/releases/17.01.0/targets/x86/kvm_guest/
Chaos Calmer 15.05.1 http://archive.openwrt.org/chaos_calmer/15.05.1/ https://downloads.openwrt.org/http://archive.openwrt.org/chaos_calmer/15.05.1/x86/kvm_guest/
Chaos Calmer 15.05 http://archive.openwrt.org/chaos_calmer/15.05/ https://downloads.openwrt.org/http://archive.openwrt.org/chaos_calmer/15.05/x86/kvm_guest/
Barrier Breaker 14.07 http://archive.openwrt.org/barrier_breaker/14.07/ https://downloads.openwrt.org/http://archive.openwrt.org/barrier_breaker/14.07/x86/kvm_guest/
Attitude Adjustment 12.09 http://archive.openwrt.org/attitude_adjustment/12.09/ https://downloads.openwrt.org/http://archive.openwrt.org/attitude_adjustment/12.09/x86/kvm_guest/
Backfire 10.03.1 http://archive.openwrt.org/backfire/10.03.1/ https://downloads.openwrt.org/http://archive.openwrt.org/backfire/10.03.1/x86/kvm_guest/
Backfire 10.03 http://archive.openwrt.org/backfire/10.03/ https://downloads.openwrt.org/http://archive.openwrt.org/backfire/10.03/x86/kvm_guest/
for F in `ls *.img.gz`; do gunzip -f $F; done
ls: cannot access '*.img.gz': No such file or directory
make docker-image
make[1]: Entering directory '/home/enukane/Sources/vrnetlab/openwrt'
for IMAGE in ; do \
        echo "Making $IMAGE"; \
        make IMAGE=$IMAGE docker-build; \
done
make[1]: Leaving directory '/home/enukane/Sources/vrnetlab/openwrt'
```

after
```
% make build
python3 download.py
OpenWrt 18.06.4 releases/18.06.4/targets/ https://downloads.openwrt.org/releases/18.06.4/targets/x86/kvm_guest/
LEDE 17.01.6 releases/17.01.6/targets/ https://downloads.openwrt.org/releases/17.01.6/targets/x86/kvm_guest/
OpenWrt 18.06.3 http://archive.openwrt.org/releases/18.06.3/targets/ http://archive.openwrt.org/releases/18.06.3/targets/x86/kvm_guest/
OpenWrt 18.06.2 http://archive.openwrt.org/releases/18.06.2/targets/ http://archive.openwrt.org/releases/18.06.2/targets/x86/kvm_guest/
OpenWrt 18.06.1 http://archive.openwrt.org/releases/18.06.1/targets/ http://archive.openwrt.org/releases/18.06.1/targets/x86/kvm_guest/
OpenWrt 18.06.0 http://archive.openwrt.org/releases/18.06.0/targets/ http://archive.openwrt.org/releases/18.06.0/targets/x86/kvm_guest/
LEDE 17.01.5 http://archive.openwrt.org/releases/17.01.5/targets/ http://archive.openwrt.org/releases/17.01.5/targets/x86/kvm_guest/
LEDE 17.01.4 http://archive.openwrt.org/releases/17.01.4/targets/ http://archive.openwrt.org/releases/17.01.4/targets/x86/kvm_guest/
LEDE 17.01.3 http://archive.openwrt.org/releases/17.01.3/targets/ http://archive.openwrt.org/releases/17.01.3/targets/x86/kvm_guest/
LEDE 17.01.2 http://archive.openwrt.org/releases/17.01.2/targets/ http://archive.openwrt.org/releases/17.01.2/targets/x86/kvm_guest/
LEDE 17.01.1 http://archive.openwrt.org/releases/17.01.1/targets/ http://archive.openwrt.org/releases/17.01.1/targets/x86/kvm_guest/
LEDE 17.01.0 http://archive.openwrt.org/releases/17.01.0/targets/ http://archive.openwrt.org/releases/17.01.0/targets/x86/kvm_guest/
Chaos Calmer 15.05.1 http://archive.openwrt.org/chaos_calmer/15.05.1/ http://archive.openwrt.org/chaos_calmer/15.05.1/x86/kvm_guest/
Downloading http://archive.openwrt.org/chaos_calmer/15.05.1/x86/kvm_guest/combined-ext4.img.gz -> openwrt-15.05-x86-kvm_guest-combined-ext4.img.gz
Chaos Calmer 15.05 http://archive.openwrt.org/chaos_calmer/15.05/ http://archive.openwrt.org/chaos_calmer/15.05/x86/kvm_guest/
Downloading http://archive.openwrt.org/chaos_calmer/15.05/x86/kvm_guest/combined-ext4.img.gz -> openwrt-15.05-x86-kvm_guest-combined-ext4.img.gz
Barrier Breaker 14.07 http://archive.openwrt.org/barrier_breaker/14.07/ http://archive.openwrt.org/barrier_breaker/14.07/x86/kvm_guest/
Downloading http://archive.openwrt.org/barrier_breaker/14.07/x86/kvm_guest/combined-ext4.img.gz -> openwrt-14.07-x86-kvm_guest-combined-ext4.img.gz
Attitude Adjustment 12.09 http://archive.openwrt.org/attitude_adjustment/12.09/ http://archive.openwrt.org/attitude_adjustment/12.09/x86/kvm_guest/
Downloading http://archive.openwrt.org/attitude_adjustment/12.09/x86/kvm_guest/combined-ext4.img.gz -> openwrt-12.09-x86-kvm_guest-combined-ext4.img.gz
Backfire 10.03.1 http://archive.openwrt.org/backfire/10.03.1/ http://archive.openwrt.org/backfire/10.03.1/x86/kvm_guest/
Backfire 10.03 http://archive.openwrt.org/backfire/10.03/ http://archive.openwrt.org/backfire/10.03/x86/kvm_guest/
for F in `ls *.img.gz`; do gunzip -f $F; done
```