### PR TITLE
Replacing obsolete 'usbdevice' option

### DIFF
--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -45,8 +45,9 @@ class VMX_vcp(vrnetlab.VM):
                        "type=1,manufacturer=Juniper,product=VM-vcp_vmx2-161-re-0,version=0.1.0"]
         # add metadata image if it exists
         if os.path.exists("/vmx/metadata-usb-re.img"):
-            self.qemu_args.extend(["-usb", "-usbdevice", "disk:format=raw:/vmx/metadata-usb-re.img"])
-
+            self.qemu_args.extend(
+                ["-usb", "-drive", "id=my_usb_disk,media=disk,format=raw,file=/vmx/metadata-usb-re.img,if=none",
+                 "-device", "usb-storage,drive=my_usb_disk"])
 
 
     def start(self):
@@ -176,7 +177,9 @@ class VMX_vfpc(vrnetlab.VM):
         self.qemu_args.extend(["-cpu", "SandyBridge", "-M", "pc", "-smp", "3"])
         # add metadata image if it exists
         if os.path.exists("/vmx/metadata-usb-fpc0.img"):
-            self.qemu_args.extend(["-usb", "-usbdevice", "disk:format=raw:/vmx/metadata-usb-fpc0.img"])
+            self.qemu_args.extend(
+                ["-usb", "-drive", "id=fpc_usb_disk,media=disk,format=raw,file=/vmx/metadata-usb-fpc0.img,if=none",
+                 "-device", "usb-storage,drive=fpc_usb_disk"])
 
 
 


### PR DESCRIPTION
QEMU emulator version 3.1.0 (Debian 1:3.1+dfsg-8+deb10u2) throws the below error (Please see issue #210 for details)

> 2019-09-19 22:21:23,064: vrnetlab INFO STDERR: qemu-system-x86_64: -usbdevice disk:format=raw:/vmx/metadata-usb-re.img: '-usbdevice' is deprecated, please use '-device usb-...' instead
qemu-system-x86_64: -usbdevice disk:format=raw:/vmx/metadata-usb-re.img: could not add USB device 'disk:format=raw:/vmx/metadata-usb-re.img'
2019-09-19 22:21:23,066: vrnetlab INFO Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 1)

The commit fix that issue by replacing obsolete options with the newer one.
c839819
