### PR TITLE
Add suport for custom vMX builds

### DIFF
--- a/vmx/Makefile
+++ b/vmx/Makefile
@@ -12,7 +12,7 @@ IMAGE_GLOB=*.tgz
 # vmx-bundle-17.1R1.8.tgz
 # vmx-bundle-16.1R4-S2.2.tgz
 # vmx-bundle-17.1R1-S1.tgz
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9][0-9]\.[0-9][A-Z][0-9]\+\(\.[0-9]\+\|-S[0-9]\+\(\.[0-9]\+\)\?\)\)[^0-9].*$$/\1/')
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9][0-9]\.[0-9][A-Z][0-9]\+\(\.[0-9]\+\|-[SD][0-9]\+\(\.[0-9]\+\)\?\)\)[^0-9].*$$/\1/')
 
 -include ../makefile-sanity.include
 -include ../makefile.include

--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -249,11 +249,11 @@ class VMX(vrnetlab.VR):
 
     def read_version(self):
         for e in os.listdir("/vmx/"):
-            m = re.search("-(([0-9][0-9])\.([0-9])([A-Z])([0-9]+)\.([0-9]+))", e)
+            m = re.search("-(([0-9][0-9])\.([0-9])([A-Z])([0-9]+)(\-D[0-9]*)?\.([0-9]+))", e)
             if m:
                 self.vcp_image = e
                 self.version = m.group(1)
-                self.version_info = [int(m.group(2)), int(m.group(3)), m.group(4), int(m.group(5)), int(m.group(6))]
+                self.version_info = [int(m.group(2)), int(m.group(3)), m.group(4), int(m.group(5)), int(m.group(7))]
 
 
 class VMX_installer(VMX):


### PR DESCRIPTION
This adjusts the regexes used in the vMX packaging to support images with custom build versions (i.e. a -D in the version)