### PR TITLE
Modify gen_nics() to assign correct ports > 99

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -190,8 +190,8 @@ class VM:
                        'mac': gen_mac(i)
                     })
             res.append("-netdev")
-            res.append("socket,id=p%(i)02d,listen=:100%(i)02d"
-                       % { 'i': i })
+            res.append("socket,id=p%(i)02d,listen=:%(j)02d"
+                       % { 'i': i, 'j': i + 10000 })
         return res
 
 


### PR DESCRIPTION
When using more than 99 nics, this function does not
work as expected. Instead of arithmetic, it relies on simply
prefixing a value of i with 100.
Closes #223