### PR TITLE
upgrade to exabgp4

### DIFF
--- a/vr-bgp/Dockerfile
+++ b/vr-bgp/Dockerfile
@@ -8,22 +8,18 @@ RUN apt-get update -qy \
  && apt-get upgrade -qy \
  && apt-get install -y \
     iputils-tracepath \
-    git \
-    golang \
     procps \
-    python \
-    python-setuptools \
     python3-jinja2 \
     python3-flask \
+    python3-pip \
+    sqlite3
     tcpdump \
     telnet \
+    vim \
     wget \
- && rm -rf /var/lib/apt/lists/* \
- && wget -O exabgp.tar.gz https://github.com/Exa-Networks/exabgp/archive/4.0.10.tar.gz \
- && tar zxvf exabgp.tar.gz \
- && cd /exabgp* && python setup.py install \
- && cd / && rm -rf exabgp*
+RUN pip3 install exabgp
 
-ADD . /
+
+ADD *bgp* /
 
 ENTRYPOINT ["/vr-bgp.py"]

--- a/vr-bgp/Dockerfile
+++ b/vr-bgp/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -qy \
     telnet \
     wget \
  && rm -rf /var/lib/apt/lists/* \
- && wget -O exabgp.tar.gz https://github.com/Exa-Networks/exabgp/archive/3.4.18.tar.gz \
+ && wget -O exabgp.tar.gz https://github.com/Exa-Networks/exabgp/archive/4.0.10.tar.gz \
  && tar zxvf exabgp.tar.gz \
  && cd /exabgp* && python setup.py install \
  && cd / && rm -rf exabgp*

--- a/vr-bgp/bgprec.py
+++ b/vr-bgp/bgprec.py
@@ -67,7 +67,7 @@ def parse_message(line):
     timestamp = datetime.fromtimestamp(msg['time'])
 
     if msg['type'] == 'state':
-        neighbor_ip = msg['neighbor']['ip']
+        neighbor_ip = msg['neighbor']['address']['peer']
         state = msg['neighbor']['state']
         upsert_neighbor_state(neighbor_ip, state, timestamp)
 
@@ -88,13 +88,13 @@ def parse_message(line):
                                 # and parse GUA
                                 continue
                             for prefix in prefixes:
-                                log("announce {}".format(prefix))
+                                log("announce {}".format(prefix['nlri']))
                                 attributes = update['attribute']
                                 # store next-hop, which is NLRI information as
                                 # (path) attribute. this is not according to
                                 # RFC but gosh does it simplify things.
                                 attributes['next-hop'] = nexthop
-                                upsert_prefix(afi, prefix, attributes)
+                                upsert_prefix(afi, prefix['nlri'], attributes)
 
             # handle withdraws
             if 'withdraw' in update:

--- a/vr-bgp/exabgp.conf.tpl
+++ b/vr-bgp/exabgp.conf.tpl
@@ -1,69 +1,72 @@
-group test {
-    process bgpapi {
-        run /bgpapi.py;
-    }
+process bgpapi {
+    encoder json;
+    run /bgpapi.py;
+}
 
-    process bgprec {
-        encoder json;
-        receive {
+process bgprec {
+    encoder json;
+    run /bgprec.py;
+}
+
+template test {
+    neighbor test {
+        router-id {{config.ROUTER_ID}};
+        local-as {{config.LOCAL_AS}};
+        api connection {
+            processes [ bgprec ];
             neighbor-changes;
-            parsed;
-            update;
+            receive {
+                parsed;
+                update;
+            }
         }
-        run /bgprec.py;
+        {%- if config.ROUTEREFRESH %}
+        capability {
+            route-refresh;
+        }
+        {%- endif %}
     }
-
-    router-id {{config.ROUTER_ID}};
-    local-as {{config.LOCAL_AS}};
+}
 
 {%- if config.IPV4_NEIGHBOR %}
-    neighbor {{config.IPV4_NEIGHBOR}} {
-        peer-as {{config.PEER_AS}};
-        local-address {{config.IPV4_LOCAL_ADDRESS}};
-        {%- if not config.ALLOW_MIXED_AFI_TRANSPORT %}
-        family {
-            ipv4 unicast;
-        }
-        {%- endif %}
-        {%- if config.MD5 %}
-        md5 "{{config.MD5}}";
-        {%- endif %}
-        {%- if config.LISTEN %}
-        listen 179;
-        {%- endif %}
-        {%- if config.TTLSECURITY %}
-        ttl-security;
-        {%- endif %}
-        {%- if config.ROUTEREFRESH %}
-        capability {
-            route-refresh;
-        }
-        {%- endif %}
+neighbor {{config.IPV4_NEIGHBOR}} {
+    inherit test;
+    peer-as {{config.PEER_AS}};
+    local-address {{config.IPV4_LOCAL_ADDRESS}};
+    {%- if not config.ALLOW_MIXED_AFI_TRANSPORT %}
+    family {
+        ipv4 unicast;
     }
+    {%- endif %}
+    {%- if config.MD5 %}
+    md5 "{{config.MD5}}";
+    {%- endif %}
+    {%- if config.LISTEN %}
+    listen 179;
+    {%- endif %}
+    {%- if config.TTLSECURITY %}
+    ttl-security;
+    {%- endif %}
+}
 {%- endif %}
 {%- if config.IPV6_NEIGHBOR %}
-    neighbor {{config.IPV6_NEIGHBOR}} {
-        peer-as {{config.PEER_AS}};
-        local-address {{config.IPV6_LOCAL_ADDRESS}};
-        {%- if not config.ALLOW_MIXED_AFI_TRANSPORT %}
-        family {
-            ipv6 unicast;
-        }
-        {%- endif %}
-        {%- if config.MD5 %}
-        md5 "{{config.MD5}}";
-        {%- endif %}
-        {%- if config.LISTEN %}
-        listen 179;
-        {%- endif %}
-        {%- if config.TTLSECURITY %}
-        ttl-security;
-        {%- endif %}
-        {%- if config.ROUTEREFRESH %}
-        capability {
-            route-refresh;
-        }
-        {%- endif %}
+neighbor {{config.IPV6_NEIGHBOR}} {
+    inherit test;
+    peer-as {{config.PEER_AS}};
+    local-address {{config.IPV6_LOCAL_ADDRESS}};
+    {%- if not config.ALLOW_MIXED_AFI_TRANSPORT %}
+    family {
+        ipv6 unicast;
     }
-{%- endif %}
+    {%- endif %}
+    {%- if config.MD5 %}
+    md5 "{{config.MD5}}";
+    {%- endif %}
+    {%- if config.LISTEN %}
+    listen 179;
+    {%- endif %}
+    {%- if config.TTLSECURITY %}
+    ttl-security;
+    {%- endif %}
 }
+{%- endif %}

--- a/vr-bgp/exabgp.conf.tpl
+++ b/vr-bgp/exabgp.conf.tpl
@@ -35,7 +35,9 @@ group test {
         ttl-security;
         {%- endif %}
         {%- if config.ROUTEREFRESH %}
-        route-refresh;
+        capability {
+            route-refresh;
+        }
         {%- endif %}
     }
 {%- endif %}
@@ -58,7 +60,9 @@ group test {
         ttl-security;
         {%- endif %}
         {%- if config.ROUTEREFRESH %}
-        route-refresh;
+        capability {
+            route-refresh;
+        }
         {%- endif %}
     }
 {%- endif %}

--- a/vr-bgp/exabgp.conf.tpl
+++ b/vr-bgp/exabgp.conf.tpl
@@ -34,6 +34,9 @@ group test {
         {%- if config.TTLSECURITY %}
         ttl-security;
         {%- endif %}
+        {%- if config.ROUTEREFRESH %}
+        route-refresh;
+        {%- endif %}
     }
 {%- endif %}
 {%- if config.IPV6_NEIGHBOR %}
@@ -53,6 +56,9 @@ group test {
         {%- endif %}
         {%- if config.TTLSECURITY %}
         ttl-security;
+        {%- endif %}
+        {%- if config.ROUTEREFRESH %}
+        route-refresh;
         {%- endif %}
     }
 {%- endif %}

--- a/vr-bgp/vr-bgp.py
+++ b/vr-bgp/vr-bgp.py
@@ -85,6 +85,7 @@ if __name__ == '__main__':
     parser.add_argument('--trace', action='store_true', help='enable trace level logging')
     parser.add_argument('--vlan', type=int, help='VLAN ID to use')
     parser.add_argument('--ttl-security', action="store_true", help='Enable TTL security')
+    parser.add_argument('--route-refresh', action="store_true", help='Enable Route Refresh')
     args = parser.parse_args()
 
     LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
@@ -107,7 +108,8 @@ if __name__ == '__main__':
         'INTERFACE': 'tap0',
         'INTERFACE_VLAN': None,
         'ALLOW_MIXED_AFI_TRANSPORT': args.allow_mixed_afi_transport,
-        'TTLSECURITY': args.ttl_security
+        'TTLSECURITY': args.ttl_security,
+        'ROUTEREFRESH': args.route_refresh
     }
 
     if args.vlan:

--- a/vr-xcon/Dockerfile
+++ b/vr-xcon/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
notes:
- exabgp can be installed with pip, modified Dockerfile
- vr-xcon needs to be upgraded to buster, pip wouldnt install exabgp on stretch.
- slight change in log file format so bgprec.py needed to be updated a bit
- exabgp config file template updated
- route-refesh support added

i have tested announcing and receiving routes

```
root@98eafd65d7d8:/tmp# sqlite3 bgp.
SQLite version 3.27.2 2019-02-25 16:06:06
Enter ".help" for usage hints.
sqlite> select * from neighbors;
1.0.0.1|up|2021-01-22 17:03:47.933853
sqlite> select * from received_routes;
ipv4 unicast|2.0.0.0/24|{"origin": "incomplete", "as-path": [1], "confederation-path": [], "med": 0, "next-hop": "1.0.0.1"}
ipv4 unicast|1.0.0.0/31|{"origin": "incomplete", "as-path": [1], "confederation-path": [], "med": 0, "next-hop": "1.0.0.1"}
ipv4 unicast|10.0.0.0/24|{"origin": "incomplete", "as-path": [1], "confederation-path": [], "med": 0, "next-hop": "1.0.0.1"}
```

announcing:
```
172.17.0.1 - - [22/Jan/2021 17:05:54] "POST /announce HTTP/1.1" 200 -
17:05:54 | 9      | api             | route added to neighbor 1.0.0.1 local-ip 1.0.0.0 local-as 2 peer-as 1 router-id 1.1.1.1 family-allowed in-open : 128.0.0.0/24 next-hop self
```

