### PR TITLE
Add dummy interface to 18.4R1.8.

### DIFF
--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -194,7 +194,7 @@ class VMX_vfpc(vrnetlab.VM):
         res.extend(["-netdev",
                     "tap,ifname=vfpc-int,id=vfpc-int,script=no,downscript=no"])
 
-        if self.version in ('15.1F6.9', '16.1R2.11', '17.2R1.13'):
+        if self.version in ('15.1F6.9', '16.1R2.11', '17.2R1.13', '18.4R1.8'):
             # dummy interface for some vMX versions - not sure why vFPC wants
             # it but without it we get a misalignment
             res.extend(["-device", "virtio-net-pci,netdev=dummy,mac=%s" %


### PR DESCRIPTION
VMX 18.4R1 also needs the dummy interface to work correctly.