### PR TITLE
Add VFPC login expect string for newer VMX images

### DIFF
--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -231,6 +231,7 @@ class VMX_vfpc(vrnetlab.VM):
         return
 
 
+
 class VMX(vrnetlab.VR):
     """ Juniper vMX router
     """

--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -215,12 +215,12 @@ class VMX_vfpc(vrnetlab.VM):
 
 
     def bootstrap_spin(self):
-        (ridx, match, res) = self.tn.expect([b"localhost login", b"mounting /dev/sda2 on /mnt failed"], 1)
+        (ridx, match, res) = self.tn.expect([b"localhost login", b"qemux86-64 login", b"mounting /dev/sda2 on /mnt failed"], 1)
         if match:
-            if ridx == 0: # got login - vFPC start succeeded!
+            if ridx == 0 or ridx == 1: # got login - vFPC start succeeded!
                 self.logger.info("vFPC successfully started")
                 self.running = True
-            if ridx == 1: # vFPC start failed - restart it
+            if ridx == 2: # vFPC start failed - restart it
                 self.logger.info("vFPC start failed, restarting")
                 self.stop()
                 self.start()
@@ -229,7 +229,6 @@ class VMX_vfpc(vrnetlab.VM):
             #self.logger.trace("OUTPUT VFPC: %s" % res.decode())
 
         return
-
 
 
 class VMX(vrnetlab.VR):


### PR DESCRIPTION
The VFPC VMX images has a different login name (qemux86-64 vs localhost).
This will add "qemux86-64 login" to what we look for if the VFPC has booted.
This has been tested on: 18.4R1.8, 18.4R3.3, 19.4R3.11 and 20.4R1.12.