### PR TITLE
Use debian:bullseye as base image

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -75,7 +75,7 @@ class VM:
         self.qemu_args.extend(["-monitor", "tcp:0.0.0.0:40%02d,server,nowait" % self.num])
         self.qemu_args.extend(["-m", str(ram),
                                "-serial", "telnet:0.0.0.0:50%02d,server,nowait" % self.num,
-                               "-drive", "if=ide,file=%s" % overlay_disk_image])
+                               "-drive", "if=ide,file=%s,file.locking=off" % overlay_disk_image])
         # enable hardware assist if KVM is available
         if os.path.exists("/dev/kvm"):
             self.qemu_args.insert(1, '-enable-kvm')

--- a/csr/docker/Dockerfile
+++ b/csr/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/nxos/docker/Dockerfile
+++ b/nxos/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/openwrt/docker/Dockerfile
+++ b/openwrt/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/routeros/docker/Dockerfile
+++ b/routeros/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/sros/docker/Dockerfile
+++ b/sros/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/topology-machine/Dockerfile
+++ b/topology-machine/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/veos/docker/Dockerfile
+++ b/veos/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/vmx/docker/Dockerfile
+++ b/vmx/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/vmx/docker/launch.py
+++ b/vmx/docker/launch.py
@@ -36,7 +36,7 @@ class VMX_vcp(vrnetlab.VM):
         super(VMX_vcp, self).__init__(username, password, disk_image=image, ram=2048)
         self.install_mode = install_mode
         self.num_nics = 0
-        self.qemu_args.extend(["-drive", "if=ide,file=/vmx/vmxhdd.img"])
+        self.qemu_args.extend(["-drive", "if=ide,file=/vmx/vmxhdd.img,file.locking=off"])
         self.smbios = ["type=0,vendor=Juniper",
                        "type=1,manufacturer=Juniper,product=VM-vcp_vmx2-161-re-0,version=0.1.0"]
         # insert bootstrap config file into metadata image

--- a/vqfx/docker/Dockerfile
+++ b/vqfx/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/vr-xcon/Dockerfile
+++ b/vr-xcon/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/vrp/docker/Dockerfile
+++ b/vrp/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 RUN apt-get update -qy \

--- a/vsr1000/docker/Dockerfile
+++ b/vsr1000/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/xrv/docker/Dockerfile
+++ b/xrv/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/xrv9k/docker/Dockerfile
+++ b/xrv9k/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
The errors when running beyond debian:stretch was due to the newer
packaged qemu-system-x86_64 locking the image file when starting a new VR.
The file lock failed when this was run inside docker since docker's
overlay file system did not suppoort file locking.

We can workaround this by passing the hidden option "file.locking=off" when
executing qemu-system-x86_64, allowing the VR to start without image file
locking.

I have tested this with xrv9k and sros without problems.