### PR TITLE
Add NX-OS 9000v

### DIFF
--- a/common/vrnetlab.py
+++ b/common/vrnetlab.py
@@ -45,6 +45,7 @@ class VM:
 
     def __init__(self, username, password, disk_image=None, num=0, ram=4096):
         self.logger = logging.getLogger()
+        self.start_time = datetime.datetime.now()
 
         # username / password to configure
         self.username = username
@@ -65,17 +66,12 @@ class VM:
         self.num_nics = 0
         self.nics_per_pci_bus = 26 # tested to work with XRv
         self.smbios = []
-        overlay_disk_image = re.sub(r'(\.[^.]+$)', r'-overlay\1', disk_image)
-
-        if not os.path.exists(overlay_disk_image):
-            self.logger.debug("Creating overlay disk image")
-            run_command(["qemu-img", "create", "-f", "qcow2", "-b", disk_image, overlay_disk_image])
 
         self.qemu_args = ["qemu-system-x86_64", "-display", "none", "-machine", "pc" ]
         self.qemu_args.extend(["-monitor", "tcp:0.0.0.0:40%02d,server,nowait" % self.num])
         self.qemu_args.extend(["-m", str(ram),
-                               "-serial", "telnet:0.0.0.0:50%02d,server,nowait" % self.num,
-                               "-drive", "if=ide,file=%s" % overlay_disk_image])
+                               "-serial", "telnet:0.0.0.0:50%02d,server,nowait" % self.num])
+        self.qemu_args.extend(self.create_overlay_image())
         # enable hardware assist if KVM is available
         if os.path.exists("/dev/kvm"):
             self.qemu_args.insert(1, '-enable-kvm')
@@ -84,7 +80,6 @@ class VM:
 
     def start(self):
         self.logger.info("Starting %s" % self.__class__.__name__)
-        self.start_time = datetime.datetime.now()
 
         cmd = list(self.qemu_args)
 
@@ -194,6 +189,18 @@ class VM:
                        % { 'i': i, 'j': i + 10000 })
         return res
 
+
+    def create_overlay_image(self):
+        """Creates an overlay image if one does not exist and return
+           an array of parameters to extend qemu_args,
+           A subclass may want to override this for using specific drive id.
+        """
+        overlay_disk_image = re.sub(r'(\.[^.]+$)', r'-overlay\1', self.image)
+
+        if not os.path.exists(overlay_disk_image):
+            self.logger.debug("Creating overlay disk image")
+            run_command(["qemu-img", "create", "-f", "qcow2", "-b", self.image, overlay_disk_image])
+        return ["-drive", "if=ide,file=%s" % overlay_disk_image]
 
 
     def stop(self):

--- a/nxos9kv/Makefile
+++ b/nxos9kv/Makefile
@@ -1,0 +1,14 @@
+VENDOR=Cisco
+NAME=NX-OS 9000v
+IMAGE_FORMAT=qcow2
+IMAGE_GLOB=*.qcow2
+
+# match versions like:
+# nexus9300v.9.3.7.qcow2
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\.[0-9]\.[0-9].*\)\.qcow2$$/\1/')
+
+-include ../makefile-sanity.include
+-include ../makefile.include
+
+docker-pre-build:
+	cp OVMF-pure-efi.fd nxos_config.txt docker

--- a/nxos9kv/README.md
+++ b/nxos9kv/README.md
@@ -1,0 +1,64 @@
+vrnetlab / Cisco NX-OSv 9000
+============================
+This is the vrnetlab docker image for Cisco NX-OSv 9000 Virtual Switch.
+
+Building the docker image
+-------------------------
+This is the officially supported image and is different from the Titanium
+emulator. The image can be downloaded directly from Cisco site.
+
+Additional files needed
+-----------------------
+You need to download the nexus9x00v image from Cisco. You will also need to
+download the EFI boot image, such as the one from 
+https://www.kraxel.org/repos/jenkins/edk2. You need to extract the 
+OVMF-pure-efi.fd file from the RPM package, this EFI boot image is used to
+boot up the nexus9x00v image.
+
+Anyway, put the .qcow2 and the fd files in this directory and run 
+`make docker-image` and you should be good to go. The resulting image
+is called `vr-nxos9k`. You can tag it with something else if you want,
+like `my-repo.example.com/vr-nxos9k` and then push it to your repo. The tag
+is the same as the version of the NXOS image, so if you have
+nexus9300v.9.3.7.qcow2 your final docker image will be called vr-nxos:9.3.7.
+
+Usage
+-----
+```
+docker run -d --privileged --name my-nxos-router vr-nxos9k:9.3.7
+```
+You may specify the number of NICs with --num-nics, the default is 24 with a
+maximum of 65 for 9300v.
+
+Initial Configuration
+---------------------
+The initial configuration file called nxos_config.txt is required. This file
+should contain some minimal configuration. A sample configuration is included.
+
+System requirements
+-------------------
+
+Currently there are two platforms, 9300v and 9500v. If you are using vrnetlab
+I assume you want the light weight 9300v. The resource requirement is based on
+9300v.
+
+CPU: 1 core, 2 prefered, the VR is not stable in my tests with 1 core.
+
+RAM: 8GB, Cisco recommends 4GB, but in my case 4GB is not enough.
+
+Disk: 8GB
+
+I only tested with 9300v.
+
+Known issues
+------------
+It is known that a previously booted image may not start properly. We have
+implemented a check that once a container stops then restarts, all its
+configurations (stored in the overlay image) are wiped clean before running.
+You will have to configure from scratch for each run.
+
+FUAQ - Frequently or Unfrequently Asked Questions
+-------------------------------------------------
+##### Q: Has this been extensively tested?
+A: Only basic configuration by the author on Ubuntu 20.04 server running Intel
+Xeon chips, both CLI and Netconf work. Layer2/layer3 functions are not tested.

--- a/nxos9kv/docker/Dockerfile
+++ b/nxos9kv/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:stretch
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+ && apt-get upgrade -qy \
+ && apt-get install -y \
+    bridge-utils \
+    genisoimage \
+    iproute2 \
+    python3-ipy \
+    socat \
+    qemu-kvm \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE
+# binary files
+COPY $IMAGE *.fd /
+# the rest
+COPY *.py *.txt /
+
+EXPOSE 22 161/udp 830 5000 10000-10099
+HEALTHCHECK CMD ["/healthcheck.py"]
+ENTRYPOINT ["/launch.py"]

--- a/nxos9kv/docker/launch.py
+++ b/nxos9kv/docker/launch.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+
+import argparse
+import datetime
+import logging
+import os
+import re
+import signal
+import sys
+
+import vrnetlab
+
+def handle_SIGCHLD(signal, frame):
+    os.waitpid(-1, os.WNOHANG)
+
+def handle_SIGTERM(signal, frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, handle_SIGTERM)
+signal.signal(signal.SIGTERM, handle_SIGTERM)
+signal.signal(signal.SIGCHLD, handle_SIGCHLD)
+
+TRACE_LEVEL_NUM = 9
+logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
+
+def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    if self.isEnabledFor(TRACE_LEVEL_NUM):
+        self._log(TRACE_LEVEL_NUM, message, args, **kws)
+
+logging.Logger.trace = trace
+
+
+
+class NXOS9K_vm(vrnetlab.VM):
+    def __init__(self, bios, username, password, num_nics):
+        for e in os.listdir("/"):
+            if re.search(".qcow2$", e):
+                disk_image = "/" + e
+        # the parent constructor needs to call create_overlay_image,
+        # so must initialize the other parameters first
+        self.bios = bios
+        self.prompted = False
+        self.overlay_image = None
+        super().__init__(username, password, disk_image=disk_image, ram=8192)
+        self.num_nics = num_nics
+        self.credentials = [
+                ['admin', 'Cisco1234']
+            ]
+
+
+    def create_overlay_image(self):
+        self.overlay_image = re.sub(r'(\.[^.]+$)', r'-overlay\1', self.image)
+        extended_args = ['-nographic', '-bios', self.bios, '-smp', '2']
+        # remove previously old overlay image, otherwise boot fails
+        if os.path.exists(self.overlay_image):
+            os.remove(self.overlay_image)
+        # now re-create it!
+        super().create_overlay_image()
+        # use SATA driver for disk and set to drive 0
+        extended_args.extend(['-device', 'ahci,id=ahci0,bus=pci.0',
+            '-drive', 'if=none,file=%s,id=drive-sata-disk0,format=qcow2' % self.overlay_image,
+            '-device', 'ide-drive,bus=ahci0.0,drive=drive-sata-disk0,id=drive-sata-disk0'])
+        # create initial config and load it
+        vrnetlab.run_command(['genisoimage', '-o', '/cfg.iso', '-l', '--iso-level', '2', 'nxos_config.txt'])
+        extended_args.extend(['-drive', 'file=cfg.iso,media=cdrom'])
+
+
+        return extended_args
+
+    def bootstrap_spin(self):
+        """ This function should be called periodically to do work.
+        """
+
+        # press return to get prompt every 10 seconds
+        if not self.prompted and self.spins % 10 == 0:
+            self.wait_write('', wait=None)
+        if self.spins > 300:
+            # too many spins with no result ->  give up
+            self.prompted = False
+            self.stop()
+            # re-create overlay image
+            self.create_overlay_image()
+            self.start()
+            return
+
+        username, password = self.credentials[0]
+        (ridx, match, res) = self.tn.expect([b'login:', b'Enter the password for "admin":', b'Confirm the password for "admin":'], 1)
+        if match: # got a match!
+            self.prompted = True
+            self.logger.info("match found: %s", res.decode())
+            if ridx == 0: # login
+                self.logger.info("matched login prompt")
+                self.logger.info("trying to log in with %s / %s", username, password)
+                self.wait_write(username, wait=None)
+                self.wait_write(password, wait="Password:")
+
+                # run main config!
+                self.bootstrap_config()
+                # close telnet connection
+                self.tn.close()
+                # startup time?
+                startup_time = datetime.datetime.now() - self.start_time
+                self.logger.info("Startup complete in: %s", startup_time)
+                # mark as running
+                self.running = True
+            else:
+                self.logger.info("Trying to reset admin password to %s", password)
+                self.wait_write(password, wait=None)
+                self.wait_write(password, wait='password')
+
+        # no match, if we saw some output from the router it's probably
+        # booting, so let's give it some more time
+        elif res != b'':
+            self.logger.trace("OUTPUT: %s", res.decode())
+            # reset spins if we saw some output
+            self.spins = 0
+
+        self.spins += 1
+
+        return
+
+
+    def bootstrap_config(self):
+        """ Do the actual bootstrap config
+        """
+        self.logger.info("applying bootstrap configuration")
+        self.wait_write("", None)
+        # figure out the running image
+        self.wait_write("", None)
+        self.wait_write("configure")
+        self.wait_write("username %s password 0 %s role network-admin" % (self.username, self.password))
+
+        # configure mgmt interface
+        self.wait_write("interface mgmt0")
+        self.wait_write("ip address 10.0.0.15/24")
+        self.wait_write("exit")
+        # enable netconf with 10 sessions (max allowed)
+        self.wait_write("feature netconf")
+        self.wait_write("netconf sessions 10")
+        self.wait_write("exit")
+        self.wait_write("copy running-config startup-config")
+
+
+class NXOS9K(vrnetlab.VR):
+    def __init__(self, bios, username, password, num_nics):
+        super().__init__(username, password)
+        self.vms = [ NXOS9K_vm(bios, username, password, num_nics) ]
+
+def main():
+    """Main method"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--trace', action='store_true', help='enable trace level logging')
+    parser.add_argument('--username', default='vrnetlab', help='Username')
+    parser.add_argument('--password', default='VR-netlab9', help='Password')
+    parser.add_argument('--bios', default='OVMF-pure-efi.fd', help='EFI bios image')
+    parser.add_argument('--num-nics', type=int, default=24, help='Number of NICs')
+    args = parser.parse_args()
+
+    # check if the bios file exists
+    if not os.path.exists(args.bios):
+        print('Bios file %s does not exit' % args.bios)
+        sys.exit(1)
+
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    logging.basicConfig(format=LOG_FORMAT)
+    logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    if args.trace:
+        logger.setLevel(1)
+
+    vr = NXOS9K(args.bios, args.username, args.password, args.num_nics)
+    vr.start()
+
+if __name__ == '__main__':
+    main()

--- a/nxos9kv/nxos_config.txt
+++ b/nxos9kv/nxos_config.txt
@@ -1,0 +1,5 @@
+hostname nexus-switch
+username admin password Cisco1234
+interface mgmt0
+  vrf member management
+  ip address 10.0.0.15/24


### PR DESCRIPTION
This MR adds support for NX-OS 9000v. This is different from the Titanium emulator based image built in the current `nxos` directory.

This has been tested with release 9.3(7).

Please see nxos9kv/README.md for details.