### PR TITLE
nxos9kv: Handle two digit version numbers

### DIFF
--- a/nxos9kv/Makefile
+++ b/nxos9kv/Makefile
@@ -5,7 +5,8 @@ IMAGE_GLOB=*.qcow2
 
 # match versions like:
 # nexus9300v.9.3.7.qcow2
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\.[0-9]\.[0-9].*\)\.qcow2$$/\1/')
+# nexus9300v.10.3.7.F.qcow2
+VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9].*\)\.qcow2$$/\1/')
 
 -include ../makefile-sanity.include
 -include ../makefile.include


### PR DESCRIPTION
Handle version numbers such as `nexus9300v.10.3.7.F.qcow2`. The more than two digit of third version number and F suffix are handled in the current regex, so no change is required.

```
$ echo nexus9300v.10.3.7.F.qcow2 | sed -e 's/.\+[^0-9]\([0-9]\.[0-9]\.[0-9].*\)\.qcow2$/\1/'
nexus9300v.10.3.7.F.qcow2

$ echo nexus9300v.10.3.7.F.qcow2 | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9].*\)\.qcow2$/\1/'
10.3.7.F
```