### PR TITLE
Use debian:trixie for ci-builder image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
   test-vr:
     runs-on: ["self-hosted"]
     container:
-      image: vrnetlab/ci-builder
+      image: vrnetlab/ci-builder:trixie
       volumes:
         - vrnetlab-images:/vrnetlab-images
     strategy:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: vrnetlab/ci-builder
+image: vrnetlab/ci-builder:trixie
 
 variables:
   PNS: ci-${CI_PIPELINE_ID}

--- a/ci-builder-image/Dockerfile
+++ b/ci-builder-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:trixie
 
 RUN apt-get update \
  && apt-get install -y \

--- a/makefile.include
+++ b/makefile.include
@@ -73,7 +73,7 @@ docker-test-image:
 # We attach the hosts docker socket to allow creating new containers, but cannot
 # bind mount the working directory from a sibling container ..
 	-docker rm -f $(CNT_PREFIX)
-	docker create -t --name $(CNT_PREFIX) -v /var/run/docker.sock:/var/run/docker.sock vrnetlab/ci-builder /test-image -t $(TEST_TIMEOUT) $(TAG_NAME) $(CONTAINER_NAME) $(TEST_PARAMS)
+	docker create -t --name $(CNT_PREFIX) -v /var/run/docker.sock:/var/run/docker.sock vrnetlab/ci-builder:trixie /test-image -t $(TEST_TIMEOUT) $(TAG_NAME) $(CONTAINER_NAME) $(TEST_PARAMS)
 	docker cp $(CURDIR)/../test/test-image $(CNT_PREFIX):/
 	docker start --attach $(CNT_PREFIX)
 

--- a/test/test-image
+++ b/test/test-image
@@ -70,7 +70,7 @@ then
   # Test SSH connection using sshpass. We run the "exit" command, but since not
   # all platforms support it, we instead check whether an interactive session
   # was started by checking the output for the string "Entering interactive session"
-  sshpass -v -p "$ssh_password" ssh -v -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$ssh_user@$container_ip" exit 2>&1 | rg --passthru "Entering interactive session"
+  sshpass -v -p "$ssh_password" ssh -v -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-rsa "$ssh_user@$container_ip" exit 2>&1 | rg --passthru "Entering interactive session"
 
   if [ $? -eq 0 ]; then
     echo "SSH connection test passed."


### PR DESCRIPTION
This is primarily driven by the need to upgrade the Docker client, but it is also nice to keep up to date with latest Debian stable.